### PR TITLE
Installing with composer issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,5 @@
     "autoload": {
         "psr-0": { "Contrib\\Component": "src/", "Contrib\\Bundle": "src/" }
     },
-    "bin": ["composer/bin/coveralls.php"]
+    "bin": ["composer/bin/coveralls"]
 }


### PR DESCRIPTION
With the recent file name change, this now happens when installing via composer

Skipped installation of composer/bin/coveralls.php for package satooshi/php-coveralls: file not found in package

Just updating the bin path is all. :)
