### PR TITLE
Better strategy to find source file's path

### DIFF
--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollector.php
@@ -86,7 +86,7 @@ class CloverXmlCoverageCollector
      */
     protected function collectFileCoverage(\SimpleXMLElement $file, $root)
     {
-        $absolutePath = (string) $file['name'];
+        $absolutePath = (string) ($file['path'] ?: $file['name']);
 
         if (false === strpos($absolutePath, $root)) {
             return null;

--- a/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollectorTest.php
+++ b/tests/Satooshi/Bundle/CoverallsV1Bundle/Collector/CloverXmlCoverageCollectorTest.php
@@ -56,12 +56,19 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
         <line num="6" type="method" name="__construct" crap="1" count="0"/>
         <line num="8" type="stmt" count="0"/>
       </file>
+      <file path="%s/test3.php" name="test3.php">
+        <class name="TestFileBis" namespace="Hoge">
+          <metrics methods="1" coveredmethods="0" conditionals="0" coveredconditionals="0" statements="1" coveredstatements="0" elements="2" coveredelements="0"/>
+        </class>
+        <line num="6" type="method" name="__construct" crap="1" count="0"/>
+        <line num="8" type="stmt" count="0"/>
+      </file>
     </package>
   </project>
 </coverage>
 XML;
 
-        return simplexml_load_string(sprintf($xml, $this->srcDir, $this->srcDir, $this->srcDir));
+        return simplexml_load_string(sprintf($xml, $this->srcDir, $this->srcDir, $this->srcDir, $this->srcDir));
     }
 
     // getJsonFile()
@@ -98,7 +105,7 @@ XML;
     {
         $sourceFiles = $jsonFile->getSourceFiles();
 
-        $this->assertCount(2, $sourceFiles);
+        $this->assertCount(3, $sourceFiles);
 
         return $jsonFile;
     }
@@ -157,7 +164,7 @@ XML;
     {
         $sourceFiles = $jsonFile->getSourceFiles();
 
-        $this->assertCount(2, $sourceFiles);
+        $this->assertCount(3, $sourceFiles);
 
         return $jsonFile;
     }

--- a/tests/prj/files/test3.php
+++ b/tests/prj/files/test3.php
@@ -1,0 +1,10 @@
+<?php
+namespace Hoge;
+
+class TestFileBis
+{
+    public function __construct()
+    {
+        $this->message = 'hoge';
+    }
+}


### PR DESCRIPTION
In `CloverXmlCoverageCollector` the file path is taken from the `name` attribute of each `file` element in the clover report but the clover spec (which I got from Atlassian clover-ant) states that:
- the `name` attribute only contains the filename
- the `path` attribute contains the full absolute path to the file

Here is an excerpt from the clover's XSD:

``` xsd
<xs:element name="file">
    <xs:annotation>
        <xs:documentation>
            File metrics.
            @name - the file name e.g. Foo.java or Bar.groovy
            @path - the filesystem-specific original path to the file e.g. c:\path\to\Bar.groovy
        </xs:documentation>
    </xs:annotation>
    <xs:complexType>
        <xs:sequence>
            <xs:element name="metrics" type="fileMetrics"/>
            <xs:element maxOccurs="unbounded" ref="class"/>
            <xs:element minOccurs="0" maxOccurs="unbounded" ref="line"/>
         </xs:sequence>
         <xs:attribute name="name" use="required" type="xs:NCName"/>
         <xs:attribute name="path" use="required"/>
    </xs:complexType>
</xs:element>
```

So I think it would be better to use this attribute when trying to find the full path but this would probably introduce a BC break in some cases.
With this PR, I tried to add an alternative : if the `path` attribute is provided, then we use it, otherwise, we fallback on the `name` attribute as it is the actual behavior and we should keep it.
