### PR TITLE
Removed note about `composer install --dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ php-coveralls collects `count` attribute in a `line` tag from `clover.xml` if it
 
 Add `php vendor/bin/coveralls` to your `.travis.yml` at `after_script`.
 
-*Please note that `--dev` must be set to `composer install` option.*
-
 ```yml
 # .travis.yml
 language: php


### PR DESCRIPTION
For several months now the `--dev` option is enabled by default in composer. It is not present for backwards compatibility and there is a new `--no-dev` option to disable the default functionality.
