### PR TITLE
Symfony 2.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/console": ">=2.0",
         "symfony/config": ">=2.0",
         "symfony/stopwatch": ">=2.2",
-        "guzzle/guzzle": ">=3.0",
+        "guzzle/guzzle": ">=2.7",
         "psr/log": "1.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hey!

This PR does two things:
- Fix the dev deps by aliasing pdepend master as 2.0.0 because phpmd master requires pdepend 2.0.\* (maybe simply removing phpmd from the require-dev is a better solution except if you really need to get the master version).
- Allow to install the latest version of this library with Symfony 2.0 (currently not possible because guzzle requires symfony ~2.1 since 2.8.0. I have executed the testsuite with guzzle 2.7.0 and all tests are green :))
