### PR TITLE
phar building - set up platform.php for composer before building phar file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
         - php: 5.5
           env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
         - php: 5.5
-          env: 'BOX=yes'
         - php: 5.6
         - php: 7.0
+          env: 'BOX=yes'
         - php: 7.1
           env: CHECKS=yes
         - php: hhvm
@@ -35,6 +35,7 @@ after_success:
 
 before_deploy:
     - if [ "${BOX}" = "yes" ]; then curl -LSs http://box-project.github.io/box2/installer.php | php; fi;
+    - if [ "${BOX}" = "yes" ]; then composer config platform.php 2> /dev/null || composer config platform.php 5.5.0; fi;
     - if [ "${BOX}" = "yes" ]; then composer update --no-dev --no-interaction ${COMPOSER_FLAGS}; fi;
     - if [ "${BOX}" = "yes" ]; then php -d phar.readonly=false box.phar build; fi;
 


### PR DESCRIPTION
so if one decides that he needs to create phar locally on his dev (eg 7.1), file will still be valid