### PR TITLE
Fix: Use '/' instead of DIRECTORY_SEPARATOR

### DIFF
--- a/src/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollector.php
@@ -31,7 +31,7 @@ class CloverXmlCoverageCollector
      */
     public function collect(\SimpleXMLElement $xml, $rootDir)
     {
-        $root = rtrim($rootDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $root = rtrim($rootDir, '/') . '/';
 
         if ($this->jsonFile === null) {
             $this->jsonFile = new JsonFile();
@@ -107,7 +107,7 @@ class CloverXmlCoverageCollector
 
         $filename = $absolutePath;
 
-        if ($root !== DIRECTORY_SEPARATOR) {
+        if ($root !== '/') {
             $filename = str_replace($root, '', $absolutePath);
         }
 

--- a/src/Bundle/CoverallsBundle/Command/CoverallsJobsCommand.php
+++ b/src/Bundle/CoverallsBundle/Command/CoverallsJobsCommand.php
@@ -147,7 +147,7 @@ class CoverallsJobsCommand extends Command
     {
         $coverallsYmlPath = $input->getOption('config');
 
-        $ymlPath = $this->rootDir . DIRECTORY_SEPARATOR . $coverallsYmlPath;
+        $ymlPath = $this->rootDir . '/' . $coverallsYmlPath;
         $configurator = new Configurator();
 
         return $configurator

--- a/src/Component/File/Path.php
+++ b/src/Component/File/Path.php
@@ -26,7 +26,7 @@ class Path
             return !preg_match('/^[a-z]+\:\\\\/i', $path);
         }
 
-        return strpos($path, DIRECTORY_SEPARATOR) !== 0;
+        return strpos($path, '/') !== 0;
     }
 
     /**
@@ -44,7 +44,7 @@ class Path
         }
 
         if ($this->isRelativePath($path)) {
-            return $rootDir . DIRECTORY_SEPARATOR . $path;
+            return $rootDir . '/' . $path;
         }
 
         return $path;
@@ -65,7 +65,7 @@ class Path
         }
 
         if ($this->isRelativePath($path)) {
-            return realpath($rootDir . DIRECTORY_SEPARATOR . $path);
+            return realpath($rootDir . '/' . $path);
         }
 
         return realpath($path);
@@ -86,7 +86,7 @@ class Path
         }
 
         if ($this->isRelativePath($path)) {
-            return realpath($rootDir . DIRECTORY_SEPARATOR . dirname($path));
+            return realpath($rootDir . '/' . dirname($path));
         }
 
         return realpath(dirname($path));
@@ -108,7 +108,7 @@ class Path
             return false;
         }
 
-        return $realDir . DIRECTORY_SEPARATOR . basename($path);
+        return $realDir . '/' . basename($path);
     }
 
     /**

--- a/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
@@ -71,7 +71,7 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
         $sourceFiles = $jsonFile->getSourceFiles();
 
         $name1 = 'test.php';
-        $path1 = $this->srcDir . DIRECTORY_SEPARATOR . $name1;
+        $path1 = $this->srcDir . '/' . $name1;
 
         $this->assertArrayHasKey($path1, $sourceFiles);
         $this->assertSourceFileTest1($sourceFiles[$path1]);
@@ -86,7 +86,7 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
         $sourceFiles = $jsonFile->getSourceFiles();
 
         $name2 = 'test2.php';
-        $path2 = $this->srcDir . DIRECTORY_SEPARATOR . $name2;
+        $path2 = $this->srcDir . '/' . $name2;
 
         $this->assertArrayHasKey($path2, $sourceFiles);
         $this->assertSourceFileTest2($sourceFiles[$path2]);
@@ -100,7 +100,7 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
     public function shouldCollectUnderRootDir()
     {
         $xml = $this->createCloverXml();
-        $jsonFile = $this->object->collect($xml, DIRECTORY_SEPARATOR);
+        $jsonFile = $this->object->collect($xml, '/');
 
         $this->assertSame($jsonFile, $this->object->getJsonFile());
         $this->assertJsonFile($jsonFile, null, null, null, null, '2013-04-13 10:28:13 +0000');
@@ -130,7 +130,7 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
         $sourceFiles = $jsonFile->getSourceFiles();
 
         $name1 = 'test.php';
-        $path1 = $this->srcDir . DIRECTORY_SEPARATOR . $name1;
+        $path1 = $this->srcDir . '/' . $name1;
 
         $this->assertArrayHasKey($path1, $sourceFiles);
         $this->assertSourceFileTest1UnderRootDir($sourceFiles[$path1]);
@@ -145,7 +145,7 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
         $sourceFiles = $jsonFile->getSourceFiles();
 
         $name2 = 'test2.php';
-        $path2 = $this->srcDir . DIRECTORY_SEPARATOR . $name2;
+        $path2 = $this->srcDir . '/' . $name2;
 
         $this->assertArrayHasKey($path2, $sourceFiles);
         $this->assertSourceFileTest2UnderRootDir($sourceFiles[$path2]);
@@ -224,7 +224,7 @@ XML;
     protected function assertSourceFileTest1(SourceFile $sourceFile)
     {
         $name1 = 'test.php';
-        $path1 = $this->srcDir . DIRECTORY_SEPARATOR . $name1;
+        $path1 = $this->srcDir . '/' . $name1;
         $fileLines1 = 9;
         $coverage1 = array_fill(0, $fileLines1, null);
         $coverage1[6] = 3;
@@ -236,7 +236,7 @@ XML;
     protected function assertSourceFileTest2(SourceFile $sourceFile)
     {
         $name2 = 'test2.php';
-        $path2 = $this->srcDir . DIRECTORY_SEPARATOR . $name2;
+        $path2 = $this->srcDir . '/' . $name2;
         $fileLines2 = 10;
         $coverage2 = array_fill(0, $fileLines2, null);
         $coverage2[7] = 0;
@@ -248,7 +248,7 @@ XML;
     protected function assertSourceFileTest1UnderRootDir(SourceFile $sourceFile)
     {
         $name1 = 'test.php';
-        $path1 = $this->srcDir . DIRECTORY_SEPARATOR . $name1;
+        $path1 = $this->srcDir . '/' . $name1;
         $fileLines1 = 9;
         $coverage1 = array_fill(0, $fileLines1, null);
         $coverage1[6] = 3;
@@ -260,7 +260,7 @@ XML;
     protected function assertSourceFileTest2UnderRootDir(SourceFile $sourceFile)
     {
         $name2 = 'test2.php';
-        $path2 = $this->srcDir . DIRECTORY_SEPARATOR . $name2;
+        $path2 = $this->srcDir . '/' . $name2;
         $fileLines2 = 10;
         $coverage2 = array_fill(0, $fileLines2, null);
         $coverage2[7] = 0;

--- a/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
@@ -607,7 +607,7 @@ class JsonFileTest extends ProjectTestCase
      */
     public function shouldExcludeNoStatementsFiles()
     {
-        $srcDir = $this->srcDir . DIRECTORY_SEPARATOR;
+        $srcDir = $this->srcDir . '/';
 
         $object = $this->collectJsonFile();
 
@@ -643,7 +643,7 @@ class JsonFileTest extends ProjectTestCase
     protected function createSourceFile()
     {
         $filename = 'test.php';
-        $path = $this->srcDir . DIRECTORY_SEPARATOR . $filename;
+        $path = $this->srcDir . '/' . $filename;
 
         return new SourceFile($path, $filename);
     }

--- a/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
@@ -20,7 +20,7 @@ class SourceFileTest extends ProjectTestCase
         $this->setUpDir($this->projectDir);
 
         $this->filename = 'test.php';
-        $this->path = $this->srcDir . DIRECTORY_SEPARATOR . $this->filename;
+        $this->path = $this->srcDir . '/' . $this->filename;
 
         $this->object = new SourceFile($this->path, $this->filename);
     }

--- a/tests/Component/File/PathTest.php
+++ b/tests/Component/File/PathTest.php
@@ -104,7 +104,7 @@ class PathTest extends ProjectTestCase
     {
         $rootDir = '/path/to/dir';
 
-        $expected = $rootDir . DIRECTORY_SEPARATOR . $path;
+        $expected = $rootDir . '/' . $path;
 
         $this->assertSame($expected, $this->object->toAbsolutePath($path, $rootDir));
     }
@@ -145,7 +145,7 @@ class PathTest extends ProjectTestCase
     {
         $rootDir = __DIR__;
 
-        $expected = realpath($rootDir . DIRECTORY_SEPARATOR . $path);
+        $expected = realpath($rootDir . '/' . $path);
 
         $this->assertSame($expected, $this->object->getRealPath($path, $rootDir));
     }
@@ -184,7 +184,7 @@ class PathTest extends ProjectTestCase
         $path = '';
         $rootDir = __DIR__;
 
-        $expected = realpath($rootDir . DIRECTORY_SEPARATOR . $path);
+        $expected = realpath($rootDir . '/' . $path);
 
         $this->assertSame($expected, $this->object->getRealDir($path, $rootDir));
     }
@@ -223,7 +223,7 @@ class PathTest extends ProjectTestCase
         $path = 'test.txt';
         $rootDir = __DIR__;
 
-        $expected = $rootDir . DIRECTORY_SEPARATOR . $path;
+        $expected = $rootDir . '/' . $path;
 
         $this->assertSame($expected, $this->object->getRealWritingFilePath($path, $rootDir));
     }

--- a/tests/ProjectTestCase.php
+++ b/tests/ProjectTestCase.php
@@ -75,7 +75,7 @@ class ProjectTestCase extends TestCase
 
     protected function normalizePath($path)
     {
-        return strtr(DIRECTORY_SEPARATOR, '/', $path);
+        return strtr('/', '/', $path);
     }
 
     protected function assertSamePath($expected, $input, $msg = null)


### PR DESCRIPTION
This PR

* [x] uses `'/'` instead of `DIRECTORY_SEPARATOR`

Replaces https://github.com/keradus/php-coveralls/pull/1.