### PR TITLE
Groom test code

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-         bootstrap="vendor/autoload.php">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    beStrictAboutChangesToGlobalState="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    columns="max"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnRisky="false"
+    verbose="true"
+>
     <php>
         <ini name="error_reporting" value="E_ALL" />
     </php>

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -19,16 +19,6 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class JobsTest extends ProjectTestCase
 {
-    /**
-     * @var Configuration
-     */
-    private $config;
-
-    /**
-     * @var Client
-     */
-    private $client;
-
     protected function setUp()
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
@@ -484,39 +474,39 @@ class JobsTest extends ProjectTestCase
 
     protected function createJobsWith()
     {
-        $this->config = new Configuration();
+        $config = new Configuration();
 
-        $this->config
+        $config
             ->setJsonPath($this->jsonPath)
             ->setDryRun(false);
 
-        $this->client = $this->createAdapterMockWith($this->url, $this->filename);
+        $client = $this->createAdapterMockWith($this->url, $this->filename);
 
-        return new Jobs($this->config, $this->client);
+        return new Jobs($config, $client);
     }
 
     protected function createJobsNeverSend()
     {
-        $this->config = new Configuration();
-        $this->config
+        $config = new Configuration();
+        $config
             ->setJsonPath($this->jsonPath)
             ->setDryRun(false);
 
-        $this->client = $this->createAdapterMockNeverCalled();
+        $client = $this->createAdapterMockNeverCalled();
 
-        return new Jobs($this->config, $this->client);
+        return new Jobs($config, $client);
     }
 
     protected function createJobsNeverSendOnDryRun()
     {
-        $this->config = new Configuration();
-        $this->config
+        $config = new Configuration();
+        $config
             ->setJsonPath($this->jsonPath)
             ->setDryRun(true);
 
-        $this->client = $this->createAdapterMockNeverCalled();
+        $client = $this->createAdapterMockNeverCalled();
 
-        return new Jobs($this->config, $this->client);
+        return new Jobs($config, $client);
     }
 
     protected function createAdapterMockNeverCalled()

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -142,6 +142,10 @@ class JobsTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectCloverXml
+     *
+     * @param Jobs $object
+     *
+     * @return JsonFile
      */
     public function shouldHaveJsonFileAfterCollectCloverXml(Jobs $object)
     {
@@ -157,6 +161,8 @@ class JobsTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldHaveJsonFileAfterCollectCloverXml
+     *
+     * @param JsonFile $jsonFile
      */
     public function shouldNotHaveGitAfterCollectCloverXml(JsonFile $jsonFile)
     {
@@ -190,6 +196,10 @@ class JobsTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectCloverXmlExcludingNoStatementsFiles
+     *
+     * @param Jobs $object
+     *
+     * @return JsonFile
      */
     public function shouldHaveJsonFileAfterCollectCloverXmlExcludingNoStatementsFiles(Jobs $object)
     {
@@ -207,6 +217,10 @@ class JobsTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectCloverXml
+     *
+     * @param Jobs $object
+     *
+     * @return Jobs
      */
     public function shouldCollectGitInfo(Jobs $object)
     {
@@ -221,6 +235,10 @@ class JobsTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectGitInfo
+     *
+     * @param Jobs $object
+     *
+     * @return JsonFile
      */
     public function shouldHaveJsonFileAfterCollectGitInfo(Jobs $object)
     {
@@ -234,6 +252,8 @@ class JobsTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldHaveJsonFileAfterCollectGitInfo
+     *
+     * @param JsonFile $jsonFile
      */
     public function shouldHaveGitAfterCollectGitInfo(JsonFile $jsonFile)
     {
@@ -472,6 +492,9 @@ class JobsTest extends ProjectTestCase
             ->send();
     }
 
+    /**
+     * @return Jobs
+     */
     protected function createJobsWith()
     {
         $config = new Configuration();
@@ -485,6 +508,9 @@ class JobsTest extends ProjectTestCase
         return new Jobs($config, $client);
     }
 
+    /**
+     * @return Jobs
+     */
     protected function createJobsNeverSend()
     {
         $config = new Configuration();
@@ -497,6 +523,9 @@ class JobsTest extends ProjectTestCase
         return new Jobs($config, $client);
     }
 
+    /**
+     * @return Jobs
+     */
     protected function createJobsNeverSendOnDryRun()
     {
         $config = new Configuration();
@@ -509,6 +538,9 @@ class JobsTest extends ProjectTestCase
         return new Jobs($config, $client);
     }
 
+    /**
+     * @return Client
+     */
     protected function createAdapterMockNeverCalled()
     {
         $client = $this->prophesize(Client::class);
@@ -519,6 +551,12 @@ class JobsTest extends ProjectTestCase
         return $client->reveal();
     }
 
+    /**
+     * @param string $url
+     * @param string $filename
+     *
+     * @return Client
+     */
     protected function createAdapterMockWith($url, $filename)
     {
         $response = $this->prophesize(Psr7\Response::class);
@@ -538,6 +576,9 @@ class JobsTest extends ProjectTestCase
         return $client->reveal();
     }
 
+    /**
+     * @return Configuration
+     */
     protected function createConfiguration()
     {
         $config = new Configuration();
@@ -545,6 +586,9 @@ class JobsTest extends ProjectTestCase
         return $config->addCloverXmlPath($this->cloverXmlPath);
     }
 
+    /**
+     * @return string
+     */
     protected function getCloverXml()
     {
         $xml = <<<'XML'
@@ -593,6 +637,9 @@ XML;
         return sprintf($xml, $this->srcDir, $this->srcDir, $this->srcDir, $this->srcDir);
     }
 
+    /**
+     * @return \SimpleXMLElement
+     */
     protected function createCloverXml()
     {
         $xml = $this->getCloverXml();
@@ -600,6 +647,9 @@ XML;
         return simplexml_load_string($xml);
     }
 
+    /**
+     * @return string
+     */
     protected function getNoSourceCloverXml()
     {
         return <<<'XML'
@@ -618,6 +668,9 @@ XML;
 XML;
     }
 
+    /**
+     * @return \SimpleXMLElement
+     */
     protected function createNoSourceCloverXml()
     {
         $xml = $this->getNoSourceCloverXml();
@@ -625,6 +678,9 @@ XML;
         return simplexml_load_string($xml);
     }
 
+    /**
+     * @return JsonFile
+     */
     protected function collectJsonFile()
     {
         $xml = $this->createCloverXml();
@@ -633,6 +689,9 @@ XML;
         return $collector->collect($xml, $this->srcDir);
     }
 
+    /**
+     * @return JsonFile
+     */
     protected function collectJsonFileWithoutSourceFiles()
     {
         $xml = $this->createNoSourceCloverXml();
@@ -641,6 +700,11 @@ XML;
         return $collector->collect($xml, $this->srcDir);
     }
 
+    /**
+     * @param Configuration $config
+     *
+     * @return CiEnvVarsCollector
+     */
     protected function createCiEnvVarsCollector($config = null)
     {
         if ($config === null) {

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -19,6 +19,21 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class JobsTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     * @var Configuration
+     */
+    private $config;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -20,11 +20,6 @@ use PhpCoveralls\Tests\ProjectTestCase;
 class JobsTest extends ProjectTestCase
 {
     /**
-     * @var string
-     */
-    private $projectDir;
-
-    /**
      * @var Configuration
      */
     private $config;
@@ -36,9 +31,7 @@ class JobsTest extends ProjectTestCase
 
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
     protected function tearDown()

--- a/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
@@ -13,16 +13,9 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class CiEnvVarsCollectorTest extends ProjectTestCase
 {
-    /**
-     * @var string
-     */
-    private $projectDir;
-
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
     // collect()

--- a/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
@@ -13,6 +13,11 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class CiEnvVarsCollectorTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
@@ -219,6 +219,8 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectTravisCiEnvVars
+     *
+     * @param CiEnvVarsCollector $object
      */
     public function shouldHaveReadEnvAfterCollectTravisCiEnvVars(CiEnvVarsCollector $object)
     {
@@ -233,6 +235,8 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectTravisProEnvVars
+     *
+     * @param CiEnvVarsCollector $object
      */
     public function shouldHaveReadEnvAfterCollectTravisProEnvVars(CiEnvVarsCollector $object)
     {
@@ -248,6 +252,8 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectCircleCiEnvVars
+     *
+     * @param CiEnvVarsCollector $object
      */
     public function shouldHaveReadEnvAfterCollectCircleCiEnvVars(CiEnvVarsCollector $object)
     {
@@ -263,6 +269,8 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectJenkinsEnvVars
+     *
+     * @param CiEnvVarsCollector $object
      */
     public function shouldHaveReadEnvAfterCollectJenkinsEnvVars(CiEnvVarsCollector $object)
     {
@@ -278,6 +286,8 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectLocalEnvVars
+     *
+     * @param CiEnvVarsCollector $object
      */
     public function shouldHaveReadEnvAfterCollectLocalEnvVars(CiEnvVarsCollector $object)
     {
@@ -293,6 +303,8 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectUnsupportedConfig
+     *
+     * @param CiEnvVarsCollector $object
      */
     public function shouldHaveReadEnvAfterCollectUnsupportedConfig(CiEnvVarsCollector $object)
     {
@@ -305,6 +317,8 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectUnsupportedEnvVars
+     *
+     * @param CiEnvVarsCollector $object
      */
     public function shouldHaveReadEnvAfterCollectUnsupportedEnvVars(CiEnvVarsCollector $object)
     {
@@ -314,6 +328,9 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
         $this->assertArrayHasKey('COVERALLS_REPO_TOKEN', $readEnv);
     }
 
+    /**
+     * @return Configuration
+     */
     protected function createConfiguration()
     {
         $config = new Configuration();
@@ -322,6 +339,11 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
         ->addCloverXmlPath($this->cloverXmlPath);
     }
 
+    /**
+     * @param null|Configuration $config
+     *
+     * @return CiEnvVarsCollector
+     */
     protected function createCiEnvVarsCollector($config = null)
     {
         if ($config === null) {

--- a/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
@@ -15,20 +15,13 @@ use PhpCoveralls\Tests\ProjectTestCase;
 class CloverXmlCoverageCollectorTest extends ProjectTestCase
 {
     /**
-     * @var string
-     */
-    private $projectDir;
-
-    /**
      * @var CloverXmlCoverageCollector
      */
     private $object;
 
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
 
         $this->object = new CloverXmlCoverageCollector();
     }

--- a/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
@@ -14,6 +14,16 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class CloverXmlCoverageCollectorTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     * @var CloverXmlCoverageCollector
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
@@ -3,6 +3,7 @@
 namespace PhpCoveralls\Tests\Bundle\CoverallsBundle\Collector;
 
 use PhpCoveralls\Bundle\CoverallsBundle\Collector\CloverXmlCoverageCollector;
+use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Git;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\JsonFile;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\SourceFile;
 use PhpCoveralls\Tests\ProjectTestCase;
@@ -55,6 +56,10 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollect
+     *
+     * @param JsonFile $jsonFile
+     *
+     * @return JsonFile
      */
     public function shouldCollectSourceFiles(JsonFile $jsonFile)
     {
@@ -68,6 +73,8 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectSourceFiles
+     *
+     * @param JsonFile $jsonFile
      */
     public function shouldCollectSourceFileTest1(JsonFile $jsonFile)
     {
@@ -83,6 +90,8 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectSourceFiles
+     *
+     * @param JsonFile $jsonFile
      */
     public function shouldCollectSourceFileTest2(JsonFile $jsonFile)
     {
@@ -114,6 +123,10 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectUnderRootDir
+     *
+     * @param JsonFile $jsonFile
+     *
+     * @return JsonFile
      */
     public function shouldCollectSourceFilesUnderRootDir(JsonFile $jsonFile)
     {
@@ -127,6 +140,8 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectSourceFilesUnderRootDir
+     *
+     * @param JsonFile $jsonFile
      */
     public function shouldCollectSourceFileTest1UnderRootDir(JsonFile $jsonFile)
     {
@@ -142,6 +157,8 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
     /**
      * @test
      * @depends shouldCollectSourceFilesUnderRootDir
+     *
+     * @param JsonFile $jsonFile
      */
     public function shouldCollectSourceFileTest2UnderRootDir(JsonFile $jsonFile)
     {
@@ -154,6 +171,9 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
         $this->assertSourceFileTest2UnderRootDir($sourceFiles[$path2]);
     }
 
+    /**
+     * @return \SimpleXMLElement
+     */
     protected function createCloverXml()
     {
         $xml = <<<'XML'
@@ -206,6 +226,14 @@ XML;
 
     // custom assert
 
+    /**
+     * @param JsonFile $jsonFile
+     * @param string   $serviceName
+     * @param string   $serviceJobId
+     * @param string   $repoToken
+     * @param Git      $git
+     * @param string   $runAt
+     */
     protected function assertJsonFile($jsonFile, $serviceName, $serviceJobId, $repoToken, $git, $runAt)
     {
         $this->assertSame($serviceName, $jsonFile->getServiceName());
@@ -215,6 +243,14 @@ XML;
         $this->assertSame($runAt, $jsonFile->getRunAt());
     }
 
+    /**
+     * @param SourceFile $sourceFile
+     * @param string     $name
+     * @param string     $path
+     * @param int        $fileLines
+     * @param array      $coverage
+     * @param string     $source
+     */
     protected function assertSourceFile(SourceFile $sourceFile, $name, $path, $fileLines, array $coverage, $source)
     {
         $this->assertSame($name, $sourceFile->getName());

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -101,7 +101,7 @@ class GitInfoCollectorTest extends TestCase
     public function throwRuntimeExceptionIfHeadCommitIsInvalid()
     {
         $getHeadCommitValue = [];
-        $gitCommand = $this->createGitCommandStubCalledHeadCommit($this->getBranchesValue, $getHeadCommitValue, $this->getRemotesValue);
+        $gitCommand = $this->createGitCommandStubCalledHeadCommit($this->getBranchesValue, $getHeadCommitValue);
 
         $object = new GitInfoCollector($gitCommand);
 
@@ -146,7 +146,7 @@ class GitInfoCollectorTest extends TestCase
         return $stub->reveal();
     }
 
-    protected function createGitCommandStubCalledHeadCommit($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
+    protected function createGitCommandStubCalledHeadCommit($getBranchesValue, $getHeadCommitValue)
     {
         $stub = $this->prophesize(GitCommand::class);
 

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  */
 class GitInfoCollectorTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->getBranchesValue = [
             '  master',

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -124,6 +124,13 @@ class GitInfoCollectorTest extends TestCase
         $object->collect();
     }
 
+    /**
+     * @param $getBranchesValue
+     * @param $getHeadCommitValue
+     * @param $getRemotesValue
+     *
+     * @return object
+     */
     protected function createGitCommandStubWith($getBranchesValue, $getHeadCommitValue, $getRemotesValue)
     {
         $stub = $this->prophesize(GitCommand::class);
@@ -135,6 +142,11 @@ class GitInfoCollectorTest extends TestCase
         return $stub->reveal();
     }
 
+    /**
+     * @param array $getBranchesValue
+     *
+     * @return GitCommand
+     */
     protected function createGitCommandStubCalledBranches($getBranchesValue)
     {
         $stub = $this->prophesize(GitCommand::class);
@@ -146,6 +158,12 @@ class GitInfoCollectorTest extends TestCase
         return $stub->reveal();
     }
 
+    /**
+     * @param array $getBranchesValue
+     * @param array $getHeadCommitValue
+     *
+     * @return GitCommand
+     */
     protected function createGitCommandStubCalledHeadCommit($getBranchesValue, $getHeadCommitValue)
     {
         $stub = $this->prophesize(GitCommand::class);
@@ -157,6 +175,10 @@ class GitInfoCollectorTest extends TestCase
         return $stub->reveal();
     }
 
+    /**
+     * @param GitCommand $stub
+     * @param $getBranchesValue
+     */
     protected function setUpGitCommandStubWithGetBranchesOnce($stub, $getBranchesValue)
     {
         $stub
@@ -165,6 +187,10 @@ class GitInfoCollectorTest extends TestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param GitCommand $stub
+     * @param array      $getHeadCommitValue
+     */
     protected function setUpGitCommandStubWithGetHeadCommitOnce($stub, $getHeadCommitValue)
     {
         $stub
@@ -173,6 +199,9 @@ class GitInfoCollectorTest extends TestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param GitCommand $stub
+     */
     protected function setUpGitCommandStubWithGetHeadCommitNeverCalled($stub)
     {
         $stub
@@ -180,6 +209,10 @@ class GitInfoCollectorTest extends TestCase
             ->shouldNotBeCalled();
     }
 
+    /**
+     * @param GitCommand $stub
+     * @param array      $getRemotesValue
+     */
     protected function setUpGitCommandStubWithGetRemotesOnce($stub, $getRemotesValue)
     {
         $stub
@@ -188,6 +221,9 @@ class GitInfoCollectorTest extends TestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param GitCommand $stub
+     */
     protected function setUpGitCommandStubWithGetRemotesNeverCalled($stub)
     {
         $stub

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -19,38 +19,31 @@ class GitInfoCollectorTest extends TestCase
     /**
      * @var array
      */
-    private $getBranchesValue;
+    private $getBranchesValue = [
+        '  master',
+        '* branch1',
+        '  branch2',
+    ];
 
     /**
      * @var array
      */
-    private $getHeadCommitValue;
+    private $getHeadCommitValue = [
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'Author Name',
+        'author@satooshi.jp',
+        'Committer Name',
+        'committer@satooshi.jp',
+        'commit message',
+    ];
 
     /**
      * @var array
      */
-    private $getRemotesValue;
-
-    protected function setUp()
-    {
-        $this->getBranchesValue = [
-            '  master',
-            '* branch1',
-            '  branch2',
-        ];
-        $this->getHeadCommitValue = [
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            'Author Name',
-            'author@satooshi.jp',
-            'Committer Name',
-            'committer@satooshi.jp',
-            'commit message',
-        ];
-        $this->getRemotesValue = [
-            "origin\tgit@github.com:php-coveralls/php-coveralls.git (fetch)",
-            "origin\tgit@github.com:php-coveralls/php-coveralls.git (push)",
-        ];
-    }
+    private $getRemotesValue = [
+        "origin\tgit@github.com:php-coveralls/php-coveralls.git (fetch)",
+        "origin\tgit@github.com:php-coveralls/php-coveralls.git (push)",
+    ];
 
     // getCommand()
 

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -16,6 +16,21 @@ use PHPUnit\Framework\TestCase;
  */
 class GitInfoCollectorTest extends TestCase
 {
+    /**
+     * @var array
+     */
+    private $getBranchesValue;
+
+    /**
+     * @var array
+     */
+    private $getHeadCommitValue;
+
+    /**
+     * @var array
+     */
+    private $getRemotesValue;
+
     protected function setUp()
     {
         $this->getBranchesValue = [

--- a/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
+++ b/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
@@ -171,6 +171,9 @@ class CoverallsJobsCommandTest extends ProjectTestCase
         );
     }
 
+    /**
+     * @return string
+     */
     protected function getCloverXml()
     {
         $xml = <<<'XML'

--- a/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
+++ b/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
@@ -14,6 +14,11 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class CoverallsJobsCommandTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
+++ b/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
@@ -14,16 +14,9 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class CoverallsJobsCommandTest extends ProjectTestCase
 {
-    /**
-     * @var string
-     */
-    private $projectDir;
-
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
     protected function tearDown()

--- a/tests/Bundle/CoverallsBundle/Config/ConfigurationTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfigurationTest.php
@@ -12,6 +12,11 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigurationTest extends TestCase
 {
+    /**
+     * @var Configuration
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->object = new Configuration();

--- a/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
@@ -325,6 +325,12 @@ class ConfiguratorTest extends ProjectTestCase
 
     // custom assertion
 
+    /**
+     * @param Configuration $config
+     * @param array         $cloverXml
+     * @param string        $jsonPath
+     * @param bool          $excludeNoStatements
+     */
     protected function assertConfiguration(Configuration $config, array $cloverXml, $jsonPath, $excludeNoStatements = false)
     {
         $this->assertSamePaths($cloverXml, $config->getCloverXmlPaths());
@@ -332,6 +338,9 @@ class ConfiguratorTest extends ProjectTestCase
         $this->assertSame($excludeNoStatements, $config->isExcludeNoStatements());
     }
 
+    /**
+     * @return bool
+     */
     private function isWindowsOS()
     {
         static $isWindows;

--- a/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
@@ -18,20 +18,13 @@ use Symfony\Component\Console\Input\InputOption;
 class ConfiguratorTest extends ProjectTestCase
 {
     /**
-     * @var string
-     */
-    private $projectDir;
-
-    /**
      * @var Configurator
      */
     private $object;
 
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
 
         $this->srcDir = $this->rootDir . '/src';
 

--- a/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
@@ -17,6 +17,16 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class ConfiguratorTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     * @var Configurator
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
+++ b/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
@@ -13,6 +13,11 @@ use Symfony\Component\Console\Tester\ApplicationTester;
  */
 class ApplicationTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
+++ b/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
@@ -13,16 +13,9 @@ use Symfony\Component\Console\Tester\ApplicationTester;
  */
 class ApplicationTest extends ProjectTestCase
 {
-    /**
-     * @var string
-     */
-    private $projectDir;
-
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
     protected function tearDown()

--- a/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
+++ b/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
@@ -52,6 +52,9 @@ class ApplicationTest extends ProjectTestCase
         $this->assertSame(0, $actual);
     }
 
+    /**
+     * @return string
+     */
     protected function getCloverXml()
     {
         $xml = <<<'XML'

--- a/tests/Bundle/CoverallsBundle/Entity/Git/CommitTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/CommitTest.php
@@ -13,6 +13,11 @@ use PHPUnit\Framework\TestCase;
  */
 class CommitTest extends TestCase
 {
+    /**
+     * @var Commit
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->object = new Commit();

--- a/tests/Bundle/CoverallsBundle/Entity/Git/GitTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/GitTest.php
@@ -15,6 +15,26 @@ use PHPUnit\Framework\TestCase;
  */
 class GitTest extends TestCase
 {
+    /**
+     * @var string
+     */
+    private $branchName;
+
+    /**
+     * @var Commit
+     */
+    private $commit;
+
+    /**
+     * @var Remote
+     */
+    private $remote;
+
+    /**
+     * @var Git
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->branchName = 'branch_name';

--- a/tests/Bundle/CoverallsBundle/Entity/Git/GitTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/GitTest.php
@@ -91,6 +91,12 @@ class GitTest extends TestCase
         $this->assertSame(json_encode($expected), (string) $this->object);
     }
 
+    /**
+     * @param string $name
+     * @param string $url
+     *
+     * @return Remote
+     */
     protected function createRemote($name = 'name', $url = 'url')
     {
         $remote = new Remote();
@@ -100,6 +106,16 @@ class GitTest extends TestCase
             ->setUrl($url);
     }
 
+    /**
+     * @param string $id
+     * @param string $authorName
+     * @param string $authorEmail
+     * @param string $committerName
+     * @param string $committerEmail
+     * @param string $message
+     *
+     * @return Commit
+     */
     protected function createCommit($id = 'id', $authorName = 'author_name', $authorEmail = 'author_email', $committerName = 'committer_name', $committerEmail = 'committer_email', $message = 'message')
     {
         $commit = new Commit();

--- a/tests/Bundle/CoverallsBundle/Entity/Git/RemoteTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/RemoteTest.php
@@ -13,6 +13,11 @@ use PHPUnit\Framework\TestCase;
  */
 class RemoteTest extends TestCase
 {
+    /**
+     * @var Remote
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->object = new Remote();

--- a/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
@@ -20,20 +20,13 @@ use PhpCoveralls\Tests\ProjectTestCase;
 class JsonFileTest extends ProjectTestCase
 {
     /**
-     * @var string
-     */
-    private $projectDir;
-
-    /**
      * @var JsonFile
      */
     private $object;
 
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
 
         $this->object = new JsonFile();
     }

--- a/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
@@ -643,6 +643,9 @@ class JsonFileTest extends ProjectTestCase
         $this->assertNotContains('AbstractClass.php', $filenames);
     }
 
+    /**
+     * @return SourceFile
+     */
     protected function createSourceFile()
     {
         $filename = 'test.php';
@@ -651,6 +654,9 @@ class JsonFileTest extends ProjectTestCase
         return new SourceFile($path, $filename);
     }
 
+    /**
+     * @return string
+     */
     protected function getCloverXml()
     {
         $xml = <<<'XML'
@@ -699,6 +705,9 @@ XML;
         return sprintf($xml, $this->srcDir, $this->srcDir, $this->srcDir, $this->srcDir);
     }
 
+    /**
+     * @return \SimpleXMLElement
+     */
     protected function createCloverXml()
     {
         $xml = $this->getCloverXml();
@@ -706,6 +715,9 @@ XML;
         return simplexml_load_string($xml);
     }
 
+    /**
+     * @return JsonFile
+     */
     protected function collectJsonFile()
     {
         $xml = $this->createCloverXml();
@@ -714,6 +726,9 @@ XML;
         return $collector->collect($xml, $this->srcDir);
     }
 
+    /**
+     * @return string
+     */
     protected function getNoSourceCloverXml()
     {
         return <<<'XML'
@@ -732,6 +747,9 @@ XML;
 XML;
     }
 
+    /**
+     * @return \SimpleXMLElement
+     */
     protected function createNoSourceCloverXml()
     {
         $xml = $this->getNoSourceCloverXml();
@@ -739,6 +757,9 @@ XML;
         return simplexml_load_string($xml);
     }
 
+    /**
+     * @return JsonFile
+     */
     protected function collectJsonFileWithoutSourceFiles()
     {
         $xml = $this->createNoSourceCloverXml();

--- a/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
@@ -19,6 +19,16 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class JsonFileTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     * @var JsonFile
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php
@@ -12,6 +12,11 @@ use PHPUnit\Framework\TestCase;
  */
 class MetricsTest extends TestCase
 {
+    /**
+     * @var array
+     */
+    private $coverage;
+
     protected function setUp()
     {
         $this->coverage = array_fill(0, 5, null);

--- a/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
@@ -13,6 +13,21 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class SourceFileTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var SourceFile
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
@@ -16,11 +16,6 @@ class SourceFileTest extends ProjectTestCase
     /**
      * @var string
      */
-    private $projectDir;
-
-    /**
-     * @var string
-     */
     private $path;
 
     /**
@@ -30,9 +25,7 @@ class SourceFileTest extends ProjectTestCase
 
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
 
         $this->filename = 'test.php';
         $this->path = $this->srcDir . DIRECTORY_SEPARATOR . $this->filename;

--- a/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
+++ b/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
@@ -19,6 +19,11 @@ use Psr\Log\NullLogger;
  */
 class JobsRepositoryTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $projectDir;
+
     protected function setUp()
     {
         $this->projectDir = realpath(__DIR__ . '/../../..');

--- a/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
+++ b/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
@@ -10,6 +10,9 @@ use PhpCoveralls\Bundle\CoverallsBundle\Entity\Metrics;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\SourceFile;
 use PhpCoveralls\Bundle\CoverallsBundle\Repository\JobsRepository;
 use PhpCoveralls\Tests\ProjectTestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -166,6 +169,9 @@ class JobsRepositoryTest extends ProjectTestCase
         $object->persist();
     }
 
+    /**
+     * @return Jobs
+     */
     protected function createApiMockWithRequirementsNotSatisfiedException()
     {
         $api = $this->prophesize(Jobs::class);
@@ -179,6 +185,9 @@ class JobsRepositoryTest extends ProjectTestCase
         return $api->reveal();
     }
 
+    /**
+     * @return Jobs
+     */
     protected function createApiMockWithException()
     {
         $api = $this->prophesize(Jobs::class);
@@ -192,6 +201,13 @@ class JobsRepositoryTest extends ProjectTestCase
         return $api->reveal();
     }
 
+    /**
+     * @param ResponseInterface $response
+     * @param string            $statusCode
+     * @param string            $uri
+     *
+     * @return Jobs
+     */
     protected function createApiMock($response, $statusCode = '', $uri = '/')
     {
         $api = $this->prophesize(Jobs::class);
@@ -205,6 +221,9 @@ class JobsRepositoryTest extends ProjectTestCase
         return $api->reveal();
     }
 
+    /**
+     * @return LoggerInterface
+     */
     protected function createLoggerMock()
     {
         $logger = $this->prophesize(NullLogger::class);
@@ -216,6 +235,11 @@ class JobsRepositoryTest extends ProjectTestCase
 
     // dependent object
 
+    /**
+     * @param int $percent
+     *
+     * @return array
+     */
     protected function createCoverage($percent)
     {
         // percent = (covered / stmt) * 100;
@@ -263,6 +287,9 @@ class JobsRepositoryTest extends ProjectTestCase
 
     // mock
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithCollectCloverXmlCalled($api)
     {
         $api
@@ -273,6 +300,10 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param Jobs       $api
+     * @param \Exception $exception
+     */
     private function setUpJobsApiWithCollectCloverXmlThrow($api, $exception)
     {
         $api
@@ -281,6 +312,10 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param Jobs     $api
+     * @param JsonFile $jsonFile
+     */
     private function setUpJobsApiWithGetJsonFileCalled($api, $jsonFile)
     {
         $api
@@ -289,6 +324,9 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithGetJsonFileNotCalled($api)
     {
         $api
@@ -296,6 +334,9 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldNotBeCalled();
     }
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithCollectGitInfoCalled($api)
     {
         $api
@@ -306,6 +347,9 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithCollectGitInfoNotCalled($api)
     {
         $api
@@ -313,6 +357,9 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldNotBeCalled();
     }
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithCollectEnvVarsCalled($api)
     {
         $api
@@ -323,6 +370,9 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithCollectEnvVarsNotCalled($api)
     {
         $api
@@ -330,6 +380,9 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldNotBeCalled();
     }
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithDumpJsonFileCalled($api)
     {
         $api
@@ -340,6 +393,9 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldBeCalled();
     }
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithDumpJsonFileNotCalled($api)
     {
         $api
@@ -347,6 +403,12 @@ class JobsRepositoryTest extends ProjectTestCase
             ->shouldNotBeCalled();
     }
 
+    /**
+     * @param Jobs              $api
+     * @param int               $statusCode
+     * @param RequestInterface  $request
+     * @param ResponseInterface $response
+     */
     private function setUpJobsApiWithSendCalled($api, $statusCode, $request, $response)
     {
         if ($statusCode === 200) {
@@ -370,6 +432,9 @@ class JobsRepositoryTest extends ProjectTestCase
         }
     }
 
+    /**
+     * @param Jobs $api
+     */
     private function setUpJobsApiWithSendNotCalled($api)
     {
         $api

--- a/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
+++ b/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
@@ -19,16 +19,9 @@ use Psr\Log\NullLogger;
  */
 class JobsRepositoryTest extends ProjectTestCase
 {
-    /**
-     * @var string
-     */
-    private $projectDir;
-
     protected function setUp()
     {
-        $this->projectDir = realpath(__DIR__ . '/../../..');
-
-        $this->setUpDir($this->projectDir);
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
     // persist()

--- a/tests/Component/File/PathTest.php
+++ b/tests/Component/File/PathTest.php
@@ -58,6 +58,9 @@ class PathTest extends ProjectTestCase
 
     // provider
 
+    /**
+     * @return array
+     */
     public function provideRelativePaths()
     {
         return [
@@ -67,6 +70,9 @@ class PathTest extends ProjectTestCase
         ];
     }
 
+    /**
+     * @return array
+     */
     public function provideAbsolutePaths()
     {
         if ($this->isWindowsOS()) {
@@ -479,6 +485,9 @@ class PathTest extends ProjectTestCase
         chmod($this->unwritableDir, 0577);
     }
 
+    /**
+     * @return bool
+     */
     private function isWindowsOS()
     {
         static $isWindows;

--- a/tests/Component/File/PathTest.php
+++ b/tests/Component/File/PathTest.php
@@ -12,6 +12,31 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class PathTest extends ProjectTestCase
 {
+    /**
+     * @var string
+     */
+    private $existingFile;
+
+    /**
+     * @var string
+     */
+    private $unreadablePath;
+
+    /**
+     * @var string
+     */
+    private $unwritablePath;
+
+    /**
+     * @var string
+     */
+    private $unwritableDir;
+
+    /**
+     * @var Path
+     */
+    private $object;
+
     protected function setUp()
     {
         $this->existingFile = __DIR__ . '/existing.txt';

--- a/tests/Component/Log/ConsoleLoggerTest.php
+++ b/tests/Component/Log/ConsoleLoggerTest.php
@@ -26,6 +26,11 @@ class ConsoleLoggerTest extends TestCase
         $object->log('info', $message);
     }
 
+    /**
+     * @param string $message
+     *
+     * @return StreamOutput
+     */
     protected function createAdapterMockWith($message)
     {
         $mock = $this->prophesize(StreamOutput::class);

--- a/tests/Component/System/Git/GitCommandTest.php
+++ b/tests/Component/System/Git/GitCommandTest.php
@@ -127,6 +127,11 @@ class GitCommandTest extends TestCase
         $this->assertNotEmpty($actual);
     }
 
+    /**
+     * @param array $params
+     *
+     * @return GitCommand
+     */
     protected function createGitBranchesCommandMock($params)
     {
         $adapter = $this->prophesize(GitCommand::class);
@@ -138,6 +143,11 @@ class GitCommandTest extends TestCase
         return $adapter->reveal();
     }
 
+    /**
+     * @param array $params
+     *
+     * @return GitCommand
+     */
     protected function createGitHeadCommitCommandMock($params)
     {
         $adapter = $this->prophesize(GitCommand::class);
@@ -149,6 +159,11 @@ class GitCommandTest extends TestCase
         return $adapter->reveal();
     }
 
+    /**
+     * @param array $params
+     *
+     * @return GitCommand
+     */
     protected function createGitRemotesCommandMock($params)
     {
         $adapter = $this->prophesize(GitCommand::class);

--- a/tests/ProjectTestCase.php
+++ b/tests/ProjectTestCase.php
@@ -6,6 +6,56 @@ use PHPUnit\Framework\TestCase;
 
 class ProjectTestCase extends TestCase
 {
+    /**
+     * @var string
+     */
+    protected $rootDir;
+
+    /**
+     * @var string
+     */
+    protected $srcDir;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var string
+     */
+    protected $filename;
+
+    /**
+     * @var string
+     */
+    protected $buildDir;
+
+    /**
+     * @var string
+     */
+    protected $logsDir;
+
+    /**
+     * @var string
+     */
+    protected $cloverXmlPath;
+
+    /**
+     * @var string
+     */
+    protected $cloverXmlPath1;
+
+    /**
+     * @var string
+     */
+    protected $cloverXmlPath2;
+
+    /**
+     * @var string
+     */
+    protected $jsonPath;
+
     protected function setUpDir($projectDir)
     {
         $this->rootDir = realpath($projectDir . '/Fixture');

--- a/tests/ProjectTestCase.php
+++ b/tests/ProjectTestCase.php
@@ -56,6 +56,9 @@ abstract class ProjectTestCase extends TestCase
      */
     protected $jsonPath;
 
+    /**
+     * @param string $projectDir
+     */
     protected function setUpDir($projectDir)
     {
         $this->rootDir = realpath($projectDir . '/Fixture');
@@ -75,6 +78,13 @@ abstract class ProjectTestCase extends TestCase
         $this->jsonPath = $this->logsDir . '/coveralls-upload.json';
     }
 
+    /**
+     * @param string          $srcDir
+     * @param string          $logsDir
+     * @param string|string[] $cloverXmlPaths
+     * @param bool            $logsDirUnwritable
+     * @param bool            $jsonPathUnwritable
+     */
     protected function makeProjectDir($srcDir = null, $logsDir = null, $cloverXmlPaths = null, $logsDirUnwritable = false, $jsonPathUnwritable = false)
     {
         if ($srcDir !== null && !is_dir($srcDir)) {
@@ -105,6 +115,9 @@ abstract class ProjectTestCase extends TestCase
         }
     }
 
+    /**
+     * @param string $file
+     */
     protected function rmFile($file)
     {
         if (is_file($file)) {
@@ -115,6 +128,9 @@ abstract class ProjectTestCase extends TestCase
         }
     }
 
+    /**
+     * @param string $dir
+     */
     protected function rmDir($dir)
     {
         if (is_dir($dir)) {
@@ -123,11 +139,21 @@ abstract class ProjectTestCase extends TestCase
         }
     }
 
+    /**
+     * @param string $path
+     *
+     * @return string
+     */
     protected function normalizePath($path)
     {
         return strtr(DIRECTORY_SEPARATOR, '/', $path);
     }
 
+    /**
+     * @param string $expected
+     * @param string $input
+     * @param string $msg
+     */
     protected function assertSamePath($expected, $input, $msg = null)
     {
         $this->assertSame(
@@ -137,6 +163,11 @@ abstract class ProjectTestCase extends TestCase
         );
     }
 
+    /**
+     * @param string[] $expected
+     * @param string[] $input
+     * @param string   $msg
+     */
     protected function assertSamePaths(array $expected, array $input, $msg = null)
     {
         $expected = array_map(function ($path) { return $this->normalizePath($path); }, $expected);

--- a/tests/ProjectTestCase.php
+++ b/tests/ProjectTestCase.php
@@ -4,7 +4,7 @@ namespace PhpCoveralls\Tests;
 
 use PHPUnit\Framework\TestCase;
 
-class ProjectTestCase extends TestCase
+abstract class ProjectTestCase extends TestCase
 {
     /**
      * @var string


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` from `public` to `protected`
* [x] declares fields used in tests which otherwise would be declared dynamically
* [x] marks `ProjectTestCade` as abstract
* [x] inlines the field `$projectDir` as it is assigned a value, but only used to pass it into `setUpDir()`
* [x] assigns values directly, rather than during `setUp()`
* [x] inlines more fields
* [x] removes an unused parameter
* [x] adds missing docblocks
* [x] improves the `phpunit` configuration