### PR TITLE
Migrate Guzzle to Guzzlehttp for 1.0 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =============
 
+## 1.0.2
+
+### Misc
+- Migrate away from abandoned `guzzle/guzzle` to `guzzlehttp/guzzle`
+
 ## 1.0.1
 
 ### Misc

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^5.3.3 || ^7.0",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "guzzle/guzzle": "^2.8 || ^3.0",
+        "guzzlehttp/guzzle": "^2.8 || ^3.0",
         "psr/log": "^1.0",
         "symfony/config": "^2.1 || ^3.0",
         "symfony/console": "^2.1 || ^3.0",

--- a/src/Satooshi/Bundle/CoverallsV1Bundle/Version.php
+++ b/src/Satooshi/Bundle/CoverallsV1Bundle/Version.php
@@ -14,5 +14,5 @@ final class Version
      *
      * @var string
      */
-    const VERSION = '1.0.2-dev';
+    const VERSION = '1.0.2';
 }


### PR DESCRIPTION
Migrate away from abandoned `guzzle/guzzle` towards `guzzlehttp/guzzle`.

Unfortunately we have some code that still depends on `3.8` of `guzzle`, and this is causing duplicate package inclusion.