### PR TITLE
Allow Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,10 @@
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^6.0",
         "psr/log": "^1.0",
-        "symfony/config": "^2.1 || ^3.0",
-        "symfony/console": "^2.1 || ^3.0",
-        "symfony/stopwatch": "^2.0 || ^3.0",
-        "symfony/yaml": "^2.0 || ^3.0"
+        "symfony/config": "^2.1 || ^3.0 || ^4.0",
+        "symfony/console": "^2.1 || ^3.0 || ^4.0",
+        "symfony/stopwatch": "^2.0 || ^3.0 || ^4.0",
+        "symfony/yaml": "^2.0 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.4.3"


### PR DESCRIPTION
Please allow Symfony 4, otherwise it's impossible to run tests with coverage for other libraries. Thanks