### PR TITLE
Update minimum version of symfony/yaml to 2.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/config": "^2.1 || ^3.0 || ^4.0",
         "symfony/console": "^2.1 || ^3.0 || ^4.0",
         "symfony/stopwatch": "^2.0 || ^3.0 || ^4.0",
-        "symfony/yaml": "^2.0 || ^3.0 || ^4.0"
+        "symfony/yaml": "^2.0.5 || ^3.0 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0"


### PR DESCRIPTION
I'm using `php-coveralls` with `composer update --prefer-lowest` as part of my test matrix.

With 2.0.0 - 2.0.4, I get the error:

```
Error: Class 'Symfony\Component\Yaml\Parser' not found in /Users/gr4376/Projects/lib-gedcom/vendor/php-coveralls/php-coveralls/src/Bundle/CoverallsBundle/Config/Configurator.php on line 56
```

With 2.0.5, `php-coveralls` runs as expected.