### PR TITLE
Added COVERALLS_PARALLEL support and Configured CI_BUILD_NUMBER for Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,19 @@ php-coveralls set the following properties to `json_file` which is sent to Cover
 - service_name: php-coveralls
 - service_event_type: manual
 
+## Parallel Builds
+
+Coveralls provides the ability to combine coverage result from multiple parallel builds into one. To enable the feature you can set the following in your environment variable.
+
+```sh
+COVERALLS_PARALLEL=true
+```
+
+Bear in mind that you will need to configure your build to send a webhook after all the parallel builds are done in order for Coveralls to merge the results.
+
+Refer to [Parallel Builds Webhook](https://docs.coveralls.io/parallel-build-webhook) for more information for setup on your environment.
+
+
 ## CLI options
 
 You can get help information for `coveralls` with the `--help (-h)` option.

--- a/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
@@ -95,6 +95,7 @@ class CiEnvVarsCollector
     {
         if (isset($this->env['TRAVIS']) && $this->env['TRAVIS'] && isset($this->env['TRAVIS_JOB_ID'])) {
             $this->env['CI_JOB_ID'] = $this->env['TRAVIS_JOB_ID'];
+            $this->env['CI_BUILD_NUMBER'] = $this->env['TRAVIS_BUILD_NUMBER'];
 
             if ($this->config->hasServiceName()) {
                 $this->env['CI_NAME'] = $this->config->getServiceName();
@@ -106,6 +107,7 @@ class CiEnvVarsCollector
             $this->readEnv['TRAVIS'] = $this->env['TRAVIS'];
             $this->readEnv['TRAVIS_JOB_ID'] = $this->env['TRAVIS_JOB_ID'];
             $this->readEnv['CI_NAME'] = $this->env['CI_NAME'];
+            $this->readEnv['CI_BUILD_NUMBER'] = $this->env['CI_BUILD_NUMBER'];
         }
 
         return $this;

--- a/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
@@ -64,7 +64,8 @@ class CiEnvVarsCollector
             ->fillAppVeyor()
             ->fillJenkins()
             ->fillLocal()
-            ->fillRepoToken();
+            ->fillRepoToken()
+            ->fillParallel();
 
         return $this->env;
     }
@@ -222,6 +223,20 @@ class CiEnvVarsCollector
         // backup
         if (isset($this->env['COVERALLS_REPO_TOKEN'])) {
             $this->readEnv['COVERALLS_REPO_TOKEN'] = $this->env['COVERALLS_REPO_TOKEN'];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Fill parallel for parallel jobs
+     *
+     * @return $this
+     */
+    protected function fillParallel()
+    {
+        if (isset($this->env['COVERALLS_PARALLEL'])) {
+            $this->readEnv['COVERALLS_PARALLEL'] = $this->env['COVERALLS_PARALLEL'];
         }
 
         return $this;

--- a/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
@@ -231,7 +231,7 @@ class CiEnvVarsCollector
     }
 
     /**
-     * Fill parallel for parallel jobs
+     * Fill parallel for parallel jobs.
      *
      * @return $this
      */

--- a/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
@@ -87,13 +87,13 @@ class CiEnvVarsCollector
     /**
      * Fill Travis CI environment variables.
      *
-     * "TRAVIS", "TRAVIS_JOB_ID" must be set.
+     * "TRAVIS", "TRAVIS_BUILD_NUMBER", TRAVIS_JOB_ID" must be set.
      *
      * @return $this
      */
     protected function fillTravisCi()
     {
-        if (isset($this->env['TRAVIS']) && $this->env['TRAVIS'] && isset($this->env['TRAVIS_JOB_ID'])) {
+        if (isset($this->env['TRAVIS']) && $this->env['TRAVIS'] && isset($this->env['TRAVIS_JOB_ID']) && isset($this->env['TRAVIS_BUILD_NUMBER'])) {
             $this->env['CI_JOB_ID'] = $this->env['TRAVIS_JOB_ID'];
             $this->env['CI_BUILD_NUMBER'] = $this->env['TRAVIS_BUILD_NUMBER'];
 

--- a/src/Bundle/CoverallsBundle/Entity/Exception/RequirementsNotSatisfiedException.php
+++ b/src/Bundle/CoverallsBundle/Entity/Exception/RequirementsNotSatisfiedException.php
@@ -53,6 +53,7 @@ Set environment variables properly like the following.
 For Travis users:
 
   - TRAVIS
+  - TRAVIS_BUILD_NUMBER
   - TRAVIS_JOB_ID
 
 For CircleCI users:

--- a/src/Bundle/CoverallsBundle/Entity/JsonFile.php
+++ b/src/Bundle/CoverallsBundle/Entity/JsonFile.php
@@ -120,6 +120,7 @@ class JsonFile extends Coveralls
             'service_pull_request' => 'servicePullRequest',
             'service_event_type' => 'serviceEventType',
             'repo_token' => 'repoToken',
+            'parallel' => 'parallel',
             'git' => 'git',
             'run_at' => 'runAt',
             'source_files' => 'sourceFiles',
@@ -296,6 +297,30 @@ class JsonFile extends Coveralls
     public function getRepoToken()
     {
         return $this->repoToken;
+    }
+
+    /**
+     * Set parallel.
+     *
+     * @param string $parallel parallel
+     *
+     * @return $this
+     */
+    public function setParallel($parallel)
+    {
+        $this->parallel = $parallel;
+
+        return $this;
+    }
+
+    /**
+     * Return parallel.
+     *
+     * @return null|boolean
+     */
+    public function getParallel()
+    {
+        return $this->parallel;
     }
 
     /**
@@ -507,6 +532,7 @@ class JsonFile extends Coveralls
             'serviceJobId' => 'CI_JOB_ID',
             'serviceEventType' => 'COVERALLS_EVENT_TYPE',
             'repoToken' => 'COVERALLS_REPO_TOKEN',
+            'parallel' => 'COVERALLS_PARALLEL',
         ];
 
         foreach ($map as $propName => $envName) {

--- a/src/Bundle/CoverallsBundle/Entity/JsonFile.php
+++ b/src/Bundle/CoverallsBundle/Entity/JsonFile.php
@@ -99,6 +99,14 @@ class JsonFile extends Coveralls
      */
     protected $metrics;
 
+    /**
+     * If this is set, the build will not be considered done until a webhook has
+     * been sent to https://coveralls.io/webhook?repo_token=….
+     *
+     * @var bool
+     */
+    protected $parallel;
+
     // API
 
     /**

--- a/src/Bundle/CoverallsBundle/Entity/JsonFile.php
+++ b/src/Bundle/CoverallsBundle/Entity/JsonFile.php
@@ -587,7 +587,10 @@ class JsonFile extends Coveralls
      */
     protected function requireServiceJobId()
     {
-        return $this->serviceName !== null && $this->serviceJobId !== null && $this->repoToken === null;
+        return $this->serviceName !== null
+            && $this->serviceNumber !== null
+            && $this->serviceJobId !== null
+            && $this->repoToken === null;
     }
 
     /**
@@ -597,7 +600,9 @@ class JsonFile extends Coveralls
      */
     protected function requireServiceNumber()
     {
-        return $this->serviceName !== null && $this->serviceNumber !== null && $this->repoToken !== null;
+        return $this->serviceName !== null
+            && $this->serviceNumber !== null
+            && $this->repoToken !== null;
     }
 
     /**
@@ -607,7 +612,9 @@ class JsonFile extends Coveralls
      */
     protected function requireServiceEventType()
     {
-        return $this->serviceName !== null && $this->serviceEventType !== null && $this->repoToken !== null;
+        return $this->serviceName !== null
+            && $this->serviceEventType !== null
+            && $this->repoToken !== null;
     }
 
     /**
@@ -617,7 +624,8 @@ class JsonFile extends Coveralls
      */
     protected function requireRepoToken()
     {
-        return $this->serviceName === 'travis-pro' && $this->repoToken !== null;
+        return $this->serviceName === 'travis-pro'
+            && $this->repoToken !== null;
     }
 
     /**
@@ -627,6 +635,9 @@ class JsonFile extends Coveralls
      */
     protected function isUnsupportedServiceJob()
     {
-        return $this->serviceJobId === null && $this->serviceNumber === null && $this->serviceEventType === null && $this->repoToken !== null;
+        return $this->serviceJobId === null
+            && $this->serviceNumber === null
+            && $this->serviceEventType === null
+            && $this->repoToken !== null;
     }
 }

--- a/src/Bundle/CoverallsBundle/Entity/JsonFile.php
+++ b/src/Bundle/CoverallsBundle/Entity/JsonFile.php
@@ -316,7 +316,7 @@ class JsonFile extends Coveralls
     /**
      * Return parallel.
      *
-     * @return null|boolean
+     * @return null|bool
      */
     public function getParallel()
     {

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -275,6 +275,7 @@ class JobsTest extends ProjectTestCase
 
         $server = [];
         $server['TRAVIS'] = true;
+        $server['TRAVIS_BUILD_NUMBER'] = '654321';
         $server['TRAVIS_JOB_ID'] = $serviceJobId;
 
         $object = $this->createJobsWith();
@@ -300,6 +301,7 @@ class JobsTest extends ProjectTestCase
 
         $server = [];
         $server['TRAVIS'] = true;
+        $server['TRAVIS_BUILD_NUMBER'] = '8888';
         $server['TRAVIS_JOB_ID'] = $serviceJobId;
         $server['COVERALLS_REPO_TOKEN'] = $repoToken;
 
@@ -439,6 +441,7 @@ class JobsTest extends ProjectTestCase
 
         $server = [];
         $server['TRAVIS'] = true;
+        $server['TRAVIS_BUILD_NUMBER'] = '198765';
         $server['TRAVIS_JOB_ID'] = '1.1';
 
         $object = $this->createJobsNeverSendOnDryRun();
@@ -478,6 +481,7 @@ class JobsTest extends ProjectTestCase
     {
         $server = [];
         $server['TRAVIS'] = true;
+        $server['TRAVIS_BUILD_NUMBER'] = '12345';
         $server['TRAVIS_JOB_ID'] = '1.1';
         $server['COVERALLS_REPO_TOKEN'] = 'token';
         $server['GIT_COMMIT'] = 'abc123';

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -483,11 +483,10 @@ class JobsTest extends ProjectTestCase
         $server['TRAVIS'] = true;
         $server['TRAVIS_BUILD_NUMBER'] = '12345';
         $server['TRAVIS_JOB_ID'] = '1.1';
-        $server['COVERALLS_REPO_TOKEN'] = 'token';
         $server['GIT_COMMIT'] = 'abc123';
 
         $object = $this->createJobsNeverSend();
-        $jsonFile = $this->collectJsonFile();
+        $jsonFile = $this->collectJsonFileWithoutSourceFiles();
 
         $object
             ->setJsonFile($jsonFile)

--- a/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
@@ -204,6 +204,26 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
         return $object;
     }
 
+    /**
+     * @test
+     */
+    public function shouldCollectParallel()
+    {
+        $parallel = true;
+
+        $env = [];
+        $env['COVERALLS_PARALLEL'] = $parallel;
+
+        $object = $this->createCiEnvVarsCollector();
+
+        $actual = $object->collect($env);
+
+        $this->assertArrayHasKey('COVERALLS_PARALLEL', $actual);
+        $this->assertSame($parallel, $actual['COVERALLS_PARALLEL']);
+
+        return $object;
+    }
+
     // getReadEnv()
 
     /**

--- a/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
@@ -27,10 +27,12 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     {
         $serviceName = 'travis-ci';
         $serviceJobId = '1.1';
+        $serviceBuildNumber = '123456';
 
         $env = [];
         $env['TRAVIS'] = true;
         $env['TRAVIS_JOB_ID'] = $serviceJobId;
+        $env['TRAVIS_BUILD_NUMBER'] = $serviceBuildNumber;
 
         $object = $this->createCiEnvVarsCollector();
 
@@ -42,6 +44,9 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
         $this->assertArrayHasKey('CI_JOB_ID', $actual);
         $this->assertSame($serviceJobId, $actual['CI_JOB_ID']);
 
+        $this->assertArrayHasKey('CI_BUILD_NUMBER', $actual);
+        $this->assertSame($serviceBuildNumber, $actual['CI_BUILD_NUMBER']);
+
         return $object;
     }
 
@@ -52,11 +57,13 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     {
         $serviceName = 'travis-pro';
         $serviceJobId = '1.2';
+        $serviceBuildNumber = '12345';
         $repoToken = 'your_token';
 
         $env = [];
         $env['TRAVIS'] = true;
         $env['TRAVIS_JOB_ID'] = $serviceJobId;
+        $env['TRAVIS_BUILD_NUMBER'] = $serviceBuildNumber;
         $env['COVERALLS_REPO_TOKEN'] = $repoToken;
 
         $config = $this->createConfiguration();
@@ -71,6 +78,9 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
 
         $this->assertArrayHasKey('CI_JOB_ID', $actual);
         $this->assertSame($serviceJobId, $actual['CI_JOB_ID']);
+
+        $this->assertArrayHasKey('CI_BUILD_NUMBER', $actual);
+        $this->assertSame($serviceBuildNumber, $actual['CI_BUILD_NUMBER']);
 
         $this->assertArrayHasKey('COVERALLS_REPO_TOKEN', $actual);
         $this->assertSame($repoToken, $actual['COVERALLS_REPO_TOKEN']);
@@ -246,10 +256,11 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     {
         $readEnv = $object->getReadEnv();
 
-        $this->assertCount(3, $readEnv);
+        $this->assertCount(4, $readEnv);
         $this->assertArrayHasKey('TRAVIS', $readEnv);
         $this->assertArrayHasKey('TRAVIS_JOB_ID', $readEnv);
         $this->assertArrayHasKey('CI_NAME', $readEnv);
+        $this->assertArrayHasKey('CI_BUILD_NUMBER', $readEnv);
     }
 
     /**
@@ -262,10 +273,11 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     {
         $readEnv = $object->getReadEnv();
 
-        $this->assertCount(4, $readEnv);
+        $this->assertCount(5, $readEnv);
         $this->assertArrayHasKey('TRAVIS', $readEnv);
         $this->assertArrayHasKey('TRAVIS_JOB_ID', $readEnv);
         $this->assertArrayHasKey('CI_NAME', $readEnv);
+        $this->assertArrayHasKey('CI_BUILD_NUMBER', $readEnv);
         $this->assertArrayHasKey('COVERALLS_REPO_TOKEN', $readEnv);
     }
 

--- a/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
+++ b/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
@@ -45,6 +45,7 @@ class CoverallsJobsCommandTest extends ProjectTestCase
         $commandTester = new CommandTester($command);
 
         $_SERVER['TRAVIS'] = true;
+        $_SERVER['TRAVIS_BUILD_NUMBER'] = '12345';
         $_SERVER['TRAVIS_JOB_ID'] = 'command_test';
 
         $actual = $commandTester->execute(

--- a/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
+++ b/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
@@ -39,6 +39,7 @@ class ApplicationTest extends ProjectTestCase
 
         // run
         $_SERVER['TRAVIS'] = true;
+        $_SERVER['TRAVIS_BUILD_NUMBER'] = 'application_build';
         $_SERVER['TRAVIS_JOB_ID'] = 'application_test';
 
         $tester = new ApplicationTester($app);

--- a/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
@@ -205,6 +205,23 @@ class JsonFileTest extends ProjectTestCase
         return $this->object;
     }
 
+    // setParallel()
+
+    /**
+     * @test
+     */
+    public function shouldSetParallel()
+    {
+        $expected = true;
+
+        $obj = $this->object->setParallel($expected);
+
+        $this->assertSame($expected, $this->object->getParallel());
+        $this->assertSame($obj, $this->object);
+
+        return $this->object;
+    }
+
     // setServiceJobId()
 
     /**
@@ -379,6 +396,28 @@ class JsonFileTest extends ProjectTestCase
         $this->assertSame(json_encode($expected), (string) $object);
     }
 
+    // parallel
+
+    /**
+     * @test
+     * @depends shouldSetParallel
+     *
+     * @param mixed $object
+     */
+    public function shouldConvertToArrayWithParallel($object)
+    {
+        $item = true;
+
+        $expected = [
+            'parallel' => $item,
+            'source_files' => [],
+            'environment' => ['packagist_version' => Version::VERSION],
+        ];
+
+        $this->assertSame($expected, $object->toArray());
+        $this->assertSame(json_encode($expected), (string) $object);
+    }
+
     // git
 
     /**
@@ -486,6 +525,7 @@ class JsonFileTest extends ProjectTestCase
          */
 
         $repoToken = 'token';
+        $parallel = true;
         $serviceName = 'codeship';
         $serviceNumber = '108821';
         $serviceBuildUrl = 'https://www.codeship.io/projects/2777/builds/108821';
@@ -494,6 +534,7 @@ class JsonFileTest extends ProjectTestCase
 
         $env = [];
         $env['COVERALLS_REPO_TOKEN'] = $repoToken;
+        $env['COVERALLS_PARALLEL'] = $parallel;
         $env['CI_NAME'] = $serviceName;
         $env['CI_BUILD_NUMBER'] = $serviceNumber;
         $env['CI_BUILD_URL'] = $serviceBuildUrl;
@@ -506,6 +547,7 @@ class JsonFileTest extends ProjectTestCase
 
         $this->assertSame($same, $object);
         $this->assertSame($repoToken, $object->getRepoToken());
+        $this->assertSame($parallel, $object->getParallel());
         $this->assertSame($serviceName, $object->getServiceName());
         $this->assertSame($serviceNumber, $object->getServiceNumber());
         $this->assertSame($serviceBuildUrl, $object->getServiceBuildUrl());

--- a/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
@@ -473,10 +473,12 @@ class JsonFileTest extends ProjectTestCase
     {
         $serviceName = 'travis-ci';
         $serviceJobId = '1.1';
+        $serviceBuild = 123;
 
         $env = [];
         $env['CI_NAME'] = $serviceName;
         $env['CI_JOB_ID'] = $serviceJobId;
+        $env['CI_BUILD_NUMBER'] = $serviceBuild;
 
         $object = $this->collectJsonFile();
 
@@ -485,6 +487,7 @@ class JsonFileTest extends ProjectTestCase
         $this->assertSame($same, $object);
         $this->assertSame($serviceName, $object->getServiceName());
         $this->assertSame($serviceJobId, $object->getServiceJobId());
+        $this->assertSame($serviceBuild, $object->getServiceNumber());
     }
 
     /**
@@ -620,6 +623,7 @@ class JsonFileTest extends ProjectTestCase
     {
         $env = [];
         $env['TRAVIS'] = true;
+        $env['TRAVIS_BUILD_NUMBER'] = '123';
         $env['TRAVIS_JOB_ID'] = '1.1';
 
         $object = $this->collectJsonFileWithoutSourceFiles();


### PR DESCRIPTION
- Added the ability to send each build result as a parallel build by using environment variables. Following the practices in https://docs.coveralls.io/parallel-build-webhook
- Linked `TRAVIS_BUILD_NUMBER` to `CI_BUILD_NUMBER` so that the TravisCI Build number are passed in as the JSON parameters