### PR TITLE
Add Guzzle 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php": "^5.5 || ^7.0",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0",
         "psr/log": "^1.0",
         "symfony/config": "^2.1 || ^3.0 || ^4.0 || ^5.0",
         "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php": "^5.5 || ^7.0",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^6.0|^7.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "psr/log": "^1.0",
         "symfony/config": "^2.1 || ^3.0 || ^4.0 || ^5.0",
         "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0",

--- a/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
+++ b/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
@@ -418,7 +418,7 @@ class JobsRepositoryTest extends ProjectTestCase
                 ->shouldBeCalled();
         } else {
             if ($statusCode === null) {
-                $exception = \GuzzleHttp\Exception\ConnectException::create($request);
+                $exception = new \GuzzleHttp\Exception\ConnectException('Connection refused', $request);
             } elseif ($statusCode === 422) {
                 $exception = \GuzzleHttp\Exception\ClientException::create($request, $response);
             } else {


### PR DESCRIPTION
As it was described [here](https://github.com/php-coveralls/php-coveralls/issues/287), Coveralls can't be installed for the Laravel packages _(Guzzle 7 has been released a few days ago)_.

This PR adds Guzzle 7 support to fix that.