### PR TITLE
Add support for PHP 8 + PHPUnit 9

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -31,6 +31,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_order' => true,
         'phpdoc_types_order' => true,
+        'php_unit_expectation' => ['target' => '5.2'],
+        'php_unit_no_expectation_annotation' => true,
         'semicolon_after_instruction' => true,
         'single_line_throw' => false,
         'strict_comparison' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
         - php: 7.4
           env: CHECKS=yes
         - php: nightly
+          env: 'COMPOSER_FLAGS="--ignore-platform-reqs"'
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ jobs:
           env: SYMFONY_VERSION="^5.0" MIN_STABILITY=dev
         - php: 7.4
           env: CHECKS=yes
+        - php: nightly
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.5 || ^7.0 || ^8.0",
         "ext-json": "*",
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
@@ -41,7 +41,8 @@
         "symfony/yaml": "^2.0.5 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0"
+        "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "sanmai/phpunit-legacy-adapter": "^6 || ^8"
     },
     "suggest": {
         "symfony/http-kernel": "Allows Symfony integration"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-        "sanmai/phpunit-legacy-adapter": "^6 || ^8"
+        "sanmai/phpunit-legacy-adapter": "^6.1 || ^8.0"
     },
     "suggest": {
         "symfony/http-kernel": "Allows Symfony integration"

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -19,19 +19,6 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class JobsTest extends ProjectTestCase
 {
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-    }
-
-    protected function tearDown()
-    {
-        $this->rmFile($this->jsonPath);
-        $this->rmFile($this->cloverXmlPath);
-        $this->rmDir($this->logsDir);
-        $this->rmDir($this->buildDir);
-    }
-
     // getJsonFile()
 
     /**
@@ -457,10 +444,11 @@ class JobsTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
      */
     public function throwRuntimeExceptionIfInvalidEnv()
     {
+        $this->expectException(\RuntimeException::class);
+
         $server = [];
 
         $object = $this->createJobsNeverSend();
@@ -475,10 +463,11 @@ class JobsTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
      */
     public function throwRuntimeExceptionIfNoSourceFiles()
     {
+        $this->expectException(\RuntimeException::class);
+
         $server = [];
         $server['TRAVIS'] = true;
         $server['TRAVIS_BUILD_NUMBER'] = '12345';
@@ -493,6 +482,19 @@ class JobsTest extends ProjectTestCase
             ->collectEnvVars($server)
             ->dumpJsonFile()
             ->send();
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
+    }
+
+    protected function legacyTearDown()
+    {
+        $this->rmFile($this->jsonPath);
+        $this->rmFile($this->cloverXmlPath);
+        $this->rmDir($this->logsDir);
+        $this->rmDir($this->buildDir);
     }
 
     /**

--- a/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
@@ -13,11 +13,6 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class CiEnvVarsCollectorTest extends ProjectTestCase
 {
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-    }
-
     // collect()
 
     /**
@@ -358,6 +353,11 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
 
         $this->assertCount(1, $readEnv);
         $this->assertArrayHasKey('COVERALLS_REPO_TOKEN', $readEnv);
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
     /**

--- a/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
@@ -20,13 +20,6 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
      */
     private $object;
 
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-
-        $this->object = new CloverXmlCoverageCollector();
-    }
-
     // getJsonFile()
 
     /**
@@ -169,6 +162,13 @@ class CloverXmlCoverageCollectorTest extends ProjectTestCase
 
         $this->assertArrayHasKey($path2, $sourceFiles);
         $this->assertSourceFileTest2UnderRootDir($sourceFiles[$path2]);
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
+
+        $this->object = new CloverXmlCoverageCollector();
     }
 
     /**

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -7,14 +7,14 @@ use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Commit;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Git;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Remote;
 use PhpCoveralls\Component\System\Git\GitCommand;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Collector\GitInfoCollector
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class GitInfoCollectorTest extends TestCase
+class GitInfoCollectorTest extends ProjectTestCase
 {
     /**
      * @var array
@@ -78,10 +78,11 @@ class GitInfoCollectorTest extends TestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
      */
     public function throwRuntimeExceptionIfCurrentBranchNotFound()
     {
+        $this->expectException(\RuntimeException::class);
+
         $getBranchesValue = [
             '  master',
         ];
@@ -96,10 +97,11 @@ class GitInfoCollectorTest extends TestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
      */
     public function throwRuntimeExceptionIfHeadCommitIsInvalid()
     {
+        $this->expectException(\RuntimeException::class);
+
         $getHeadCommitValue = [];
         $gitCommand = $this->createGitCommandStubCalledHeadCommit($this->getBranchesValue, $getHeadCommitValue);
 
@@ -112,10 +114,11 @@ class GitInfoCollectorTest extends TestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
      */
     public function throwRuntimeExceptionIfRemoteIsInvalid()
     {
+        $this->expectException(\RuntimeException::class);
+
         $getRemotesValue = [];
         $gitCommand = $this->createGitCommandStubWith($this->getBranchesValue, $this->getHeadCommitValue, $getRemotesValue);
 

--- a/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
+++ b/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
@@ -14,19 +14,6 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class CoverallsJobsCommandTest extends ProjectTestCase
 {
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-    }
-
-    protected function tearDown()
-    {
-        $this->rmFile($this->cloverXmlPath);
-        $this->rmFile($this->jsonPath);
-        $this->rmDir($this->logsDir);
-        $this->rmDir($this->buildDir);
-    }
-
     /**
      * @test
      */
@@ -75,10 +62,11 @@ class CoverallsJobsCommandTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function shouldExecuteCoverallsJobsCommandWithWrongRootDir()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir(null, $this->logsDir);
         $this->dumpCloverXml();
 
@@ -142,10 +130,11 @@ class CoverallsJobsCommandTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function shouldExecuteCoverallsJobsCommandThrowInvalidConfigurationException()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir(null, $this->logsDir);
         $this->dumpCloverXml();
 
@@ -170,6 +159,19 @@ class CoverallsJobsCommandTest extends ProjectTestCase
                 '--coverage_clover' => 'nonexistent.xml',
             ]
         );
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
+    }
+
+    protected function legacyTearDown()
+    {
+        $this->rmFile($this->cloverXmlPath);
+        $this->rmFile($this->jsonPath);
+        $this->rmDir($this->logsDir);
+        $this->rmDir($this->buildDir);
     }
 
     /**

--- a/tests/Bundle/CoverallsBundle/Config/ConfigurationTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfigurationTest.php
@@ -3,24 +3,19 @@
 namespace PhpCoveralls\Tests\Bundle\CoverallsBundle\Config;
 
 use PhpCoveralls\Bundle\CoverallsBundle\Config\Configuration;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Config\Configuration
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class ConfigurationTest extends TestCase
+class ConfigurationTest extends ProjectTestCase
 {
     /**
      * @var Configuration
      */
     private $object;
-
-    protected function setUp()
-    {
-        $this->object = new Configuration();
-    }
 
     // hasRepoToken()
     // getRepoToken()
@@ -425,5 +420,10 @@ class ConfigurationTest extends TestCase
 
         $this->assertSame($same, $this->object);
         $this->assertSame($expected, $this->object->getEnv());
+    }
+
+    protected function legacySetUp()
+    {
+        $this->object = new Configuration();
     }
 }

--- a/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
@@ -22,26 +22,6 @@ class ConfiguratorTest extends ProjectTestCase
      */
     private $object;
 
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-
-        $this->srcDir = $this->rootDir . '/src';
-
-        $this->object = new Configurator();
-    }
-
-    protected function tearDown()
-    {
-        $this->rmFile($this->cloverXmlPath);
-        $this->rmFile($this->cloverXmlPath1);
-        $this->rmFile($this->cloverXmlPath2);
-        $this->rmFile($this->jsonPath);
-        $this->rmDir($this->srcDir);
-        $this->rmDir($this->logsDir);
-        $this->rmDir($this->buildDir);
-    }
-
     // load()
 
     /**
@@ -78,10 +58,11 @@ class ConfiguratorTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function throwInvalidConfigurationExceptionOnLoadEmptyYmlIfCoverageCloverNotFound()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir($this->srcDir, $this->logsDir, null);
 
         $path = realpath(__DIR__ . '/yaml/dummy.yml');
@@ -93,10 +74,11 @@ class ConfiguratorTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function throwInvalidConfigurationExceptionOnLoadEmptyYmlIfJsonPathDirNotWritable()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         if ($this->isWindowsOS()) {
             // On Windows read-only attribute on dir applies to files in dir, but not the dir itself.
             $this->markTestSkipped('Unable to run on Windows');
@@ -111,10 +93,11 @@ class ConfiguratorTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function throwInvalidConfigurationExceptionOnLoadEmptyYmlIfJsonPathNotWritable()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath, false, true);
 
         $path = realpath(__DIR__ . '/yaml/dummy.yml');
@@ -142,10 +125,11 @@ class ConfiguratorTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function shouldThrowInvalidConfigurationExceptionUponLoadingSrcDirYml()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
         $path = realpath(__DIR__ . '/yaml/src_dir.yml');
@@ -329,10 +313,11 @@ class ConfiguratorTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function throwInvalidConfigurationExceptionOnLoadCoverageCloverYmlIfCoverageCloverNotFound()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
         $path = realpath(__DIR__ . '/yaml/coverage_clover_not_found.yml');
@@ -342,10 +327,11 @@ class ConfiguratorTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function throwInvalidConfigurationExceptionOnLoadCoverageCloverYmlIfCoverageCloverIsNotString()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
         $path = realpath(__DIR__ . '/yaml/coverage_clover_invalid.yml');
@@ -357,10 +343,11 @@ class ConfiguratorTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function throwInvalidConfigurationExceptionOnLoadJsonPathYmlIfJsonPathNotFound()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
         $path = realpath(__DIR__ . '/yaml/json_path_not_found.yml');
@@ -372,15 +359,36 @@ class ConfiguratorTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function throwInvalidConfigurationExceptionOnLoadExcludeNoStmtYmlIfInvalid()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);
 
         $path = realpath(__DIR__ . '/yaml/exclude_no_stmt_invalid.yml');
 
         $this->object->load($path, $this->rootDir);
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
+
+        $this->srcDir = $this->rootDir . '/src';
+
+        $this->object = new Configurator();
+    }
+
+    protected function legacyTearDown()
+    {
+        $this->rmFile($this->cloverXmlPath);
+        $this->rmFile($this->cloverXmlPath1);
+        $this->rmFile($this->cloverXmlPath2);
+        $this->rmFile($this->jsonPath);
+        $this->rmDir($this->srcDir);
+        $this->rmDir($this->logsDir);
+        $this->rmDir($this->buildDir);
     }
 
     // custom assertion

--- a/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
@@ -362,6 +362,10 @@ class ConfiguratorTest extends ProjectTestCase
      */
     public function throwInvalidConfigurationExceptionOnLoadExcludeNoStmtYmlIfInvalid()
     {
+        if (PHP_VERSION_ID >= 80000 && !function_exists('get_debug_type')) {
+            $this->markTestIncomplete('get_debug_type() is not available yet');
+        }
+
         $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
 
         $this->makeProjectDir($this->srcDir, $this->logsDir, $this->cloverXmlPath);

--- a/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
+++ b/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
@@ -13,19 +13,6 @@ use Symfony\Component\Console\Tester\ApplicationTester;
  */
 class ApplicationTest extends ProjectTestCase
 {
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-    }
-
-    protected function tearDown()
-    {
-        $this->rmFile($this->cloverXmlPath);
-        $this->rmFile($this->jsonPath);
-        $this->rmDir($this->logsDir);
-        $this->rmDir($this->buildDir);
-    }
-
     /**
      * @test
      */
@@ -51,6 +38,19 @@ class ApplicationTest extends ProjectTestCase
         );
 
         $this->assertSame(0, $actual);
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
+    }
+
+    protected function legacyTearDown()
+    {
+        $this->rmFile($this->cloverXmlPath);
+        $this->rmFile($this->jsonPath);
+        $this->rmDir($this->logsDir);
+        $this->rmDir($this->buildDir);
     }
 
     /**

--- a/tests/Bundle/CoverallsBundle/Entity/Exception/RequirementsNotSatisfiedExceptionTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Exception/RequirementsNotSatisfiedExceptionTest.php
@@ -3,14 +3,14 @@
 namespace PhpCoveralls\Tests\Bundle\CoverallsBundle\Entity\Exception;
 
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Exception\RequirementsNotSatisfiedException;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Entity\Exception\RequirementsNotSatisfiedException
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class RequirementsNotSatisfiedExceptionTest extends TestCase
+class RequirementsNotSatisfiedExceptionTest extends ProjectTestCase
 {
     // getReadEnv()
 
@@ -57,7 +57,7 @@ class RequirementsNotSatisfiedExceptionTest extends TestCase
 
         $message = $object->getHelpMessage();
 
-        $this->assertContains("  - ENV_NAME='value'", $message);
+        $this->assertStringContainsString("  - ENV_NAME='value'", $message);
     }
 
     // getHelpMessage()
@@ -78,7 +78,7 @@ class RequirementsNotSatisfiedExceptionTest extends TestCase
 
         $message = $object->getHelpMessage();
 
-        $this->assertContains($expected, $message);
+        $this->assertStringContainsString($expected, $message);
     }
 
     /**
@@ -97,7 +97,7 @@ class RequirementsNotSatisfiedExceptionTest extends TestCase
 
         $message = $object->getHelpMessage();
 
-        $this->assertContains($expected, $message);
+        $this->assertStringContainsString($expected, $message);
     }
 
     /**
@@ -114,7 +114,7 @@ class RequirementsNotSatisfiedExceptionTest extends TestCase
 
         $message = $object->getHelpMessage();
 
-        $this->assertContains('  - ENV_NAME=123', $message);
+        $this->assertStringContainsString('  - ENV_NAME=123', $message);
     }
 
     /**
@@ -131,6 +131,6 @@ class RequirementsNotSatisfiedExceptionTest extends TestCase
 
         $message = $object->getHelpMessage();
 
-        $this->assertContains('  - ENV_NAME=true', $message);
+        $this->assertStringContainsString('  - ENV_NAME=true', $message);
     }
 }

--- a/tests/Bundle/CoverallsBundle/Entity/Git/CommitTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/CommitTest.php
@@ -3,7 +3,7 @@
 namespace PhpCoveralls\Tests\Bundle\CoverallsBundle\Entity\Git;
 
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Commit;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Commit
@@ -11,17 +11,12 @@ use PHPUnit\Framework\TestCase;
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class CommitTest extends TestCase
+class CommitTest extends ProjectTestCase
 {
     /**
      * @var Commit
      */
     private $object;
-
-    protected function setUp()
-    {
-        $this->object = new Commit();
-    }
 
     // getId()
 
@@ -224,5 +219,10 @@ class CommitTest extends TestCase
 
         $this->assertSame($expected, $this->object->toArray());
         $this->assertSame(json_encode($expected), (string) $this->object);
+    }
+
+    protected function legacySetUp()
+    {
+        $this->object = new Commit();
     }
 }

--- a/tests/Bundle/CoverallsBundle/Entity/Git/GitTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/GitTest.php
@@ -5,7 +5,7 @@ namespace PhpCoveralls\Tests\Bundle\CoverallsBundle\Entity\Git;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Commit;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Git;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Remote;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Git
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class GitTest extends TestCase
+class GitTest extends ProjectTestCase
 {
     /**
      * @var string
@@ -34,15 +34,6 @@ class GitTest extends TestCase
      * @var Git
      */
     private $object;
-
-    protected function setUp()
-    {
-        $this->branchName = 'branch_name';
-        $this->commit = $this->createCommit();
-        $this->remote = $this->createRemote();
-
-        $this->object = new Git($this->branchName, $this->commit, [$this->remote]);
-    }
 
     // getBranch()
 
@@ -89,6 +80,15 @@ class GitTest extends TestCase
 
         $this->assertSame($expected, $this->object->toArray());
         $this->assertSame(json_encode($expected), (string) $this->object);
+    }
+
+    protected function legacySetUp()
+    {
+        $this->branchName = 'branch_name';
+        $this->commit = $this->createCommit();
+        $this->remote = $this->createRemote();
+
+        $this->object = new Git($this->branchName, $this->commit, [$this->remote]);
     }
 
     /**

--- a/tests/Bundle/CoverallsBundle/Entity/Git/RemoteTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/RemoteTest.php
@@ -3,7 +3,7 @@
 namespace PhpCoveralls\Tests\Bundle\CoverallsBundle\Entity\Git;
 
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Remote;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Remote
@@ -11,17 +11,12 @@ use PHPUnit\Framework\TestCase;
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class RemoteTest extends TestCase
+class RemoteTest extends ProjectTestCase
 {
     /**
      * @var Remote
      */
     private $object;
-
-    protected function setUp()
-    {
-        $this->object = new Remote();
-    }
 
     // getName()
 
@@ -108,5 +103,10 @@ class RemoteTest extends TestCase
 
         $this->assertSame($expected, $this->object->toArray());
         $this->assertSame(json_encode($expected), (string) $this->object);
+    }
+
+    protected function legacySetUp()
+    {
+        $this->object = new Remote();
     }
 }

--- a/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
@@ -24,13 +24,6 @@ class JsonFileTest extends ProjectTestCase
      */
     private $object;
 
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-
-        $this->object = new JsonFile();
-    }
-
     // hasSourceFile()
     // getSourceFile()
 
@@ -604,10 +597,11 @@ class JsonFileTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \PhpCoveralls\Bundle\CoverallsBundle\Entity\Exception\RequirementsNotSatisfiedException
      */
     public function throwRuntimeExceptionOnFillingJobsIfInvalidEnv()
     {
+        $this->expectException(\PhpCoveralls\Bundle\CoverallsBundle\Entity\Exception\RequirementsNotSatisfiedException::class);
+
         $env = [];
 
         $object = $this->collectJsonFile();
@@ -617,10 +611,11 @@ class JsonFileTest extends ProjectTestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
      */
     public function throwRuntimeExceptionOnFillingJobsWithoutSourceFiles()
     {
+        $this->expectException(\RuntimeException::class);
+
         $env = [];
         $env['TRAVIS'] = true;
         $env['TRAVIS_BUILD_NUMBER'] = '123';
@@ -687,6 +682,13 @@ class JsonFileTest extends ProjectTestCase
         $this->assertContains('test2.php', $filenames);
         $this->assertNotContains('TestInterface.php', $filenames);
         $this->assertNotContains('AbstractClass.php', $filenames);
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
+
+        $this->object = new JsonFile();
     }
 
     /**

--- a/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php
@@ -3,27 +3,19 @@
 namespace PhpCoveralls\Tests\Bundle\CoverallsBundle\Entity;
 
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Metrics;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Entity\Metrics
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class MetricsTest extends TestCase
+class MetricsTest extends ProjectTestCase
 {
     /**
      * @var array
      */
     private $coverage;
-
-    protected function setUp()
-    {
-        $this->coverage = array_fill(0, 5, null);
-        $this->coverage[1] = 1;
-        $this->coverage[3] = 1;
-        $this->coverage[4] = 0;
-    }
 
     // hasStatements()
     // getStatements()
@@ -122,5 +114,13 @@ class MetricsTest extends TestCase
         $this->assertSame(6, $object->getStatements());
         $this->assertSame(4, $object->getCoveredStatements());
         $this->assertSame(400 / 6, $object->getLineCoverage());
+    }
+
+    protected function legacySetUp()
+    {
+        $this->coverage = array_fill(0, 5, null);
+        $this->coverage[1] = 1;
+        $this->coverage[3] = 1;
+        $this->coverage[4] = 0;
     }
 }

--- a/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
@@ -23,16 +23,6 @@ class SourceFileTest extends ProjectTestCase
      */
     private $object;
 
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-
-        $this->filename = 'test.php';
-        $this->path = $this->srcDir . DIRECTORY_SEPARATOR . $this->filename;
-
-        $this->object = new SourceFile($this->path, $this->filename);
-    }
-
     // getName()
 
     /**
@@ -148,5 +138,15 @@ class SourceFileTest extends ProjectTestCase
         $this->assertSame(1, $metrics->getCoveredStatements());
         $this->assertSame(100, $metrics->getLineCoverage());
         $this->assertSame(100, $this->object->reportLineCoverage());
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
+
+        $this->filename = 'test.php';
+        $this->path = $this->srcDir . DIRECTORY_SEPARATOR . $this->filename;
+
+        $this->object = new SourceFile($this->path, $this->filename);
     }
 }

--- a/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
+++ b/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
@@ -22,11 +22,6 @@ use Psr\Log\NullLogger;
  */
 class JobsRepositoryTest extends ProjectTestCase
 {
-    protected function setUp()
-    {
-        $this->setUpDir(realpath(__DIR__ . '/../../..'));
-    }
-
     // persist()
 
     /**
@@ -167,6 +162,11 @@ class JobsRepositoryTest extends ProjectTestCase
 
         $object->setLogger($logger);
         self::assertFalse($object->persist());
+    }
+
+    protected function legacySetUp()
+    {
+        $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
     /**

--- a/tests/Component/File/PathTest.php
+++ b/tests/Component/File/PathTest.php
@@ -37,25 +37,6 @@ class PathTest extends ProjectTestCase
      */
     private $object;
 
-    protected function setUp()
-    {
-        $this->existingFile = __DIR__ . '/existing.txt';
-        $this->unreadablePath = __DIR__ . '/unreadable.txt';
-        $this->unwritablePath = __DIR__ . '/unwritable.txt';
-        $this->unwritableDir = __DIR__ . '/unwritable.dir';
-
-        $this->object = new Path();
-    }
-
-    protected function tearDown()
-    {
-        $this->rmFile($this->existingFile);
-        $this->rmFile($this->unreadablePath);
-        $this->rmFile($this->unwritablePath);
-
-        $this->rmDir($this->unwritableDir);
-    }
-
     // provider
 
     /**
@@ -459,6 +440,25 @@ class PathTest extends ProjectTestCase
         $path = __DIR__;
 
         $this->assertTrue($this->object->isRealDirWritable($path));
+    }
+
+    protected function legacySetUp()
+    {
+        $this->existingFile = __DIR__ . '/existing.txt';
+        $this->unreadablePath = __DIR__ . '/unreadable.txt';
+        $this->unwritablePath = __DIR__ . '/unwritable.txt';
+        $this->unwritableDir = __DIR__ . '/unwritable.dir';
+
+        $this->object = new Path();
+    }
+
+    protected function legacyTearDown()
+    {
+        $this->rmFile($this->existingFile);
+        $this->rmFile($this->unreadablePath);
+        $this->rmFile($this->unwritablePath);
+
+        $this->rmDir($this->unwritableDir);
     }
 
     protected function touchUnreadableFile()

--- a/tests/Component/Log/ConsoleLoggerTest.php
+++ b/tests/Component/Log/ConsoleLoggerTest.php
@@ -3,7 +3,7 @@
 namespace PhpCoveralls\Tests\Component\Log;
 
 use PhpCoveralls\Component\Log\ConsoleLogger;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Output\StreamOutput;
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class ConsoleLoggerTest extends TestCase
+class ConsoleLoggerTest extends ProjectTestCase
 {
     /**
      * @test

--- a/tests/Component/System/Git/GitCommandTest.php
+++ b/tests/Component/System/Git/GitCommandTest.php
@@ -3,16 +3,15 @@
 namespace PhpCoveralls\Tests\Component\System\Git;
 
 use PhpCoveralls\Component\System\Git\GitCommand;
-use PHPUnit\Framework\TestCase;
+use PhpCoveralls\Tests\ProjectTestCase;
 
 /**
  * @covers \PhpCoveralls\Component\System\Git\GitCommand
  * @covers \PhpCoveralls\Component\System\SystemCommandExecutor
- * @covers \PhpCoveralls\Component\System\SystemCommandExecutorInterface
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */
-class GitCommandTest extends TestCase
+class GitCommandTest extends ProjectTestCase
 {
     /**
      * @test
@@ -22,7 +21,7 @@ class GitCommandTest extends TestCase
         $object = new GitCommand();
         $actual = $object->getBranches();
 
-        $this->assertInternalType('array', $actual);
+        $this->assertIsArray($actual);
         $this->assertNotEmpty($actual);
     }
 
@@ -34,7 +33,7 @@ class GitCommandTest extends TestCase
         $object = new GitCommand();
         $actual = $object->getHeadCommit();
 
-        $this->assertInternalType('array', $actual);
+        $this->assertIsArray($actual);
         $this->assertNotEmpty($actual);
         $this->assertCount(6, $actual);
     }
@@ -47,7 +46,7 @@ class GitCommandTest extends TestCase
         $object = new GitCommand();
         $actual = $object->getRemotes();
 
-        $this->assertInternalType('array', $actual);
+        $this->assertIsArray($actual);
         $this->assertNotEmpty($actual);
     }
 }

--- a/tests/ProjectTestCase.php
+++ b/tests/ProjectTestCase.php
@@ -2,7 +2,7 @@
 
 namespace PhpCoveralls\Tests;
 
-use PHPUnit\Framework\TestCase;
+use LegacyPHPUnit\TestCase;
 
 abstract class ProjectTestCase extends TestCase
 {

--- a/tests/ProjectTestCase.php
+++ b/tests/ProjectTestCase.php
@@ -56,6 +56,26 @@ abstract class ProjectTestCase extends TestCase
      */
     protected $jsonPath;
 
+    public function __call($method, $args)
+    {
+        switch ($method) {
+            case 'assertStringContainsString':
+                call_user_func_array([$this, 'assertContains'], $args);
+
+                break;
+            case 'assertIsArray':
+                call_user_func_array([$this, 'assertInternalType'], array_merge(['array'], $args));
+
+                break;
+            case 'expectException':
+                call_user_func_array([$this, 'setExpectedException'], $args);
+
+                break;
+            default:
+                trigger_error("Call to undefined method ::$method", E_USER_ERROR);
+        }
+    }
+
     /**
      * @param string $projectDir
      */


### PR DESCRIPTION
This PR
- Adds support for PHP 8 and PHPUnit 9.
- PHPUnit 8 should also work.
- It also contains [a shameless plug of an adapter package](https://github.com/sanmai/phpunit-legacy-adapter#phpunit-legacy-versions-adapter).

Replace #293
Fix #281