### PR TITLE
Fix support of branch name with hyphen and "(no branch)"

### DIFF
--- a/src/Bundle/CoverallsBundle/Collector/GitInfoCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/GitInfoCollector.php
@@ -73,6 +73,13 @@ class GitInfoCollector
         $branchesResult = $this->command->getBranches();
 
         foreach ($branchesResult as $result) {
+            if ($result === '* (no branch)') {
+                // Case detected on Travis PUSH hook for tags, can be reporduced by following command:
+                // $ git clone --depth=1 --branch=v2.4.0 https://github.com/php-coveralls/php-coveralls.git php-coveralls && cd php-coveralls && git branch
+                // * (no branch)
+                return '(no branch)';
+            }
+
             if (strpos($result, '* ') === 0) {
                 preg_match('~^\* (?:\(HEAD detached at )?([\w/]+)\)?~', $result, $matches);
 

--- a/src/Bundle/CoverallsBundle/Collector/GitInfoCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/GitInfoCollector.php
@@ -81,7 +81,7 @@ class GitInfoCollector
             }
 
             if (strpos($result, '* ') === 0) {
-                preg_match('~^\* (?:\(HEAD detached at )?([\w/]+)\)?~', $result, $matches);
+                preg_match('/^\* (?:\(HEAD detached at )?([\w\/\-]+)\)?/', $result, $matches);
 
                 return $matches[1];
             }

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -21,8 +21,8 @@ class GitInfoCollectorTest extends ProjectTestCase
      */
     private $getBranchesValue = [
         '  master',
-        '* branch1',
-        '  branch2',
+        '* branch-1',
+        '  branch-2',
     ];
 
     /**
@@ -72,6 +72,7 @@ class GitInfoCollectorTest extends ProjectTestCase
 
         $this->assertInstanceOf(Git::class, $git);
         $this->assertGit($git);
+        $this->assertSame('branch-1', $git->getBranch());
     }
 
     /**
@@ -88,6 +89,8 @@ class GitInfoCollectorTest extends ProjectTestCase
 
         $git = $object->collect();
 
+        $this->assertInstanceOf(Git::class, $git);
+        $this->assertGit($git);
         $this->assertSame('pull/1/merge', $git->getBranch());
     }
 
@@ -105,6 +108,8 @@ class GitInfoCollectorTest extends ProjectTestCase
 
         $git = $object->collect();
 
+        $this->assertInstanceOf(Git::class, $git);
+        $this->assertGit($git);
         $this->assertSame('(no branch)', $git->getBranch());
     }
 

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -91,6 +91,23 @@ class GitInfoCollectorTest extends ProjectTestCase
         $this->assertSame('pull/1/merge', $git->getBranch());
     }
 
+    /**
+     * @test
+     */
+    public function shouldCollectNoBranch()
+    {
+        $gitCommand = $this->createGitCommandStubWith(
+            ['* (no branch)'],
+            $this->getHeadCommitValue,
+            $this->getRemotesValue
+        );
+        $object = new GitInfoCollector($gitCommand);
+
+        $git = $object->collect();
+
+        $this->assertSame('(no branch)', $git->getBranch());
+    }
+
     // collectBranch() exception
 
     /**

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -120,8 +120,6 @@ class GitInfoCollectorTest extends ProjectTestCase
      */
     public function throwRuntimeExceptionIfCurrentBranchNotFound()
     {
-        $this->expectException(\RuntimeException::class);
-
         $getBranchesValue = [
             '  master',
         ];
@@ -129,6 +127,7 @@ class GitInfoCollectorTest extends ProjectTestCase
 
         $object = new GitInfoCollector($gitCommand);
 
+        $this->expectException(\RuntimeException::class);
         $object->collect();
     }
 
@@ -139,13 +138,12 @@ class GitInfoCollectorTest extends ProjectTestCase
      */
     public function throwRuntimeExceptionIfHeadCommitIsInvalid()
     {
-        $this->expectException(\RuntimeException::class);
-
         $getHeadCommitValue = [];
         $gitCommand = $this->createGitCommandStubCalledHeadCommit($this->getBranchesValue, $getHeadCommitValue);
 
         $object = new GitInfoCollector($gitCommand);
 
+        $this->expectException(\RuntimeException::class);
         $object->collect();
     }
 
@@ -156,13 +154,12 @@ class GitInfoCollectorTest extends ProjectTestCase
      */
     public function throwRuntimeExceptionIfRemoteIsInvalid()
     {
-        $this->expectException(\RuntimeException::class);
-
         $getRemotesValue = [];
         $gitCommand = $this->createGitCommandStubWith($this->getBranchesValue, $this->getHeadCommitValue, $getRemotesValue);
 
         $object = new GitInfoCollector($gitCommand);
 
+        $this->expectException(\RuntimeException::class);
         $object->collect();
     }
 
@@ -275,8 +272,6 @@ class GitInfoCollectorTest extends ProjectTestCase
 
     protected function assertGit(Git $git)
     {
-        $this->assertSame('branch1', $git->getBranch());
-
         $commit = $git->getHead();
 
         $this->assertInstanceOf(Commit::class, $commit);


### PR DESCRIPTION
ref https://github.com/php-coveralls/php-coveralls/pull/275/files#r499891969