### PR TITLE
Update README with Travis CI configuration detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ php:
   - 5.4
   - 5.3
 
+env:
+  global:
+    - XDEBUG_MODE=coverage
+
 matrix:
   allow_failures:
     - php: 5.5

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ matrix:
 install:
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install --dev --no-interaction
+
 script:
   - mkdir -p build/logs
   - php vendor/bin/phpunit -c phpunit.xml.dist


### PR DESCRIPTION
PHPUnit requires an environment variable to be set on Travis CI (`XDEBUG_MODE=coverage`). It's easy to overlook it if it's missing and can be frustrating to debug.