### PR TITLE
Disallow `psr/log` v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
-        "psr/log": "^1.0 || ^2.0 || ^3.0",
+        "psr/log": "^1.0 || ^2.0",
         "symfony/config": "^2.1 || ^3.0 || ^4.0 || ^5.0",
         "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0",
         "symfony/stopwatch": "^2.0 || ^3.0 || ^4.0 || ^5.0",


### PR DESCRIPTION
partial revert of #317

tests are failing when using psr/log@^3