### PR TITLE
Add support for GitLab CI

### DIFF
--- a/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
+++ b/src/Bundle/CoverallsBundle/Collector/CiEnvVarsCollector.php
@@ -63,6 +63,7 @@ class CiEnvVarsCollector
             ->fillCircleCi()
             ->fillAppVeyor()
             ->fillJenkins()
+            ->fillGitlab()
             ->fillGithubActions()
             ->fillLocal()
             ->fillRepoToken()
@@ -221,6 +222,31 @@ class CiEnvVarsCollector
             // backup
             $this->readEnv['BUILD_NUMBER'] = $this->env['BUILD_NUMBER'];
             $this->readEnv['JENKINS_URL'] = $this->env['JENKINS_URL'];
+            $this->readEnv['CI_NAME'] = $this->env['CI_NAME'];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Fill Jenkins environment variables.
+     *
+     * "JENKINS_URL", "BUILD_NUMBER" must be set.
+     *
+     * @return $this
+     */
+    protected function fillGitlab()
+    {
+        if (isset($this->env['CI_SERVER_NAME']) && $this->env['CI_SERVER_NAME'] === 'GitLab') {
+            $this->env['CI_BRANCH'] = $this->env['CI_COMMIT_BRANCH'];
+            $this->env['CI_BUILD_NUMBER'] = $this->env['CI_PIPELINE_IID'];
+            $this->env['CI_BUILD_URL'] = $this->env['CI_SERVER_URL'];
+            $this->env['CI_NAME'] = 'gitlab';
+
+            // backup
+            $this->readEnv['CI_COMMIT_BRANCH'] = $this->env['CI_COMMIT_BRANCH'];
+            $this->readEnv['CI_PIPELINE_IID'] = $this->env['CI_PIPELINE_IID'];
+            $this->readEnv['CI_SERVER_URL'] = $this->env['CI_SERVER_URL'];
             $this->readEnv['CI_NAME'] = $this->env['CI_NAME'];
         }
 

--- a/src/Bundle/CoverallsBundle/Entity/Exception/RequirementsNotSatisfiedException.php
+++ b/src/Bundle/CoverallsBundle/Entity/Exception/RequirementsNotSatisfiedException.php
@@ -74,13 +74,21 @@ For AppVeyor users:
   - APPVEYOR_BUILD_NUMBER
 
 For Github Actions users:
+
   - GITHUB_REF
   - GITHUB_ACTIONS
   - GITHUB_RUN_ID
   - GITHUB_EVENT_NAME
   - COVERALLS_REPO_TOKEN
 
-From local environment:
+For GitLab users:
+
+  - CI_COMMIT_BRANCH
+  - CI_SERVER_URL
+  - CI_PIPELINE_IID
+  - COVERALLS_REPO_TOKEN
+  
+For local environment:
 
   - COVERALLS_RUN_LOCALLY
   - COVERALLS_REPO_TOKEN

--- a/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
@@ -142,6 +142,42 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
     /**
      * @test
      */
+    public function shouldCollectGitLabEnvVars()
+    {
+        $serviceName = 'gitlab';
+        $serviceNumber = '123';
+        $buildUrl = 'http://localhost:8080';
+        $branch = 'test';
+
+        $env = [];
+        $env['CI_SERVER_NAME'] = 'GitLab';
+        $env['COVERALLS_REPO_TOKEN'] = 'token';
+        $env['CI_SERVER_URL'] = $buildUrl;
+        $env['CI_PIPELINE_IID'] = $serviceNumber;
+        $env['CI_COMMIT_BRANCH'] = $branch;
+
+        $object = $this->createCiEnvVarsCollector();
+
+        $actual = $object->collect($env);
+
+        $this->assertArrayHasKey('CI_NAME', $actual);
+        $this->assertSame($serviceName, $actual['CI_NAME']);
+
+        $this->assertArrayHasKey('CI_BUILD_NUMBER', $actual);
+        $this->assertSame($serviceNumber, $actual['CI_BUILD_NUMBER']);
+
+        $this->assertArrayHasKey('CI_BUILD_URL', $actual);
+        $this->assertSame($buildUrl, $actual['CI_BUILD_URL']);
+
+        $this->assertArrayHasKey('CI_BRANCH', $actual);
+        $this->assertSame($branch, $actual['CI_BRANCH']);
+
+        return $object;
+    }
+
+    /**
+     * @test
+     */
     public function shouldCollectGithubActionsEnvVars()
     {
         $serviceName = 'github';
@@ -422,6 +458,24 @@ class CiEnvVarsCollectorTest extends ProjectTestCase
         $this->assertArrayHasKey('COVERALLS_REPO_TOKEN', $readEnv);
         $this->assertArrayHasKey('JENKINS_URL', $readEnv);
         $this->assertArrayHasKey('BUILD_NUMBER', $readEnv);
+        $this->assertArrayHasKey('CI_NAME', $readEnv);
+    }
+
+    /**
+     * @test
+     * @depends shouldCollectGitLabEnvVars
+     *
+     * @param CiEnvVarsCollector $object
+     */
+    public function shouldHaveReadEnvAfterCollectGitLabEnvVars(CiEnvVarsCollector $object)
+    {
+        $readEnv = $object->getReadEnv();
+
+        $this->assertCount(5, $readEnv);
+        $this->assertArrayHasKey('COVERALLS_REPO_TOKEN', $readEnv);
+        $this->assertArrayHasKey('CI_COMMIT_BRANCH', $readEnv);
+        $this->assertArrayHasKey('CI_PIPELINE_IID', $readEnv);
+        $this->assertArrayHasKey('CI_SERVER_URL', $readEnv);
         $this->assertArrayHasKey('CI_NAME', $readEnv);
     }
 


### PR DESCRIPTION
This PR adds support for GitLab CI. I only tested it with our on-premise gitlab, maybe someone can confirm with gitlab SAAS?

From the coveralls-upload.json:
```
{
  "service_name": "gitlab",
  "service_number": "499",
  "service_build_url": "https://gitlab.xxx",
  "service_branch": "test",
  ...
}
```
