### PR TITLE
Switch to prophecy-phpunit trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
+        "phpspec/prophecy-phpunit": "^2.0",
         "psr/log": "^1.0 || ^2.0",
         "symfony/config": "^2.1 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
         "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0 || ^6.0",

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -10,6 +10,7 @@ use PhpCoveralls\Bundle\CoverallsBundle\Collector\CloverXmlCoverageCollector;
 use PhpCoveralls\Bundle\CoverallsBundle\Config\Configuration;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\JsonFile;
 use PhpCoveralls\Tests\ProjectTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Api\Jobs
@@ -19,6 +20,8 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class JobsTest extends ProjectTestCase
 {
+    use ProphecyTrait;
+
     // getJsonFile()
 
     /**

--- a/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/GitInfoCollectorTest.php
@@ -8,6 +8,7 @@ use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Git;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\Git\Remote;
 use PhpCoveralls\Component\System\Git\GitCommand;
 use PhpCoveralls\Tests\ProjectTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 /**
  * @covers \PhpCoveralls\Bundle\CoverallsBundle\Collector\GitInfoCollector
@@ -16,6 +17,8 @@ use PhpCoveralls\Tests\ProjectTestCase;
  */
 class GitInfoCollectorTest extends ProjectTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var array
      */

--- a/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
+++ b/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
@@ -10,6 +10,7 @@ use PhpCoveralls\Bundle\CoverallsBundle\Entity\Metrics;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\SourceFile;
 use PhpCoveralls\Bundle\CoverallsBundle\Repository\JobsRepository;
 use PhpCoveralls\Tests\ProjectTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
@@ -22,6 +23,8 @@ use Psr\Log\NullLogger;
  */
 class JobsRepositoryTest extends ProjectTestCase
 {
+    use ProphecyTrait;
+
     // persist()
 
     /**

--- a/tests/Component/Log/ConsoleLoggerTest.php
+++ b/tests/Component/Log/ConsoleLoggerTest.php
@@ -4,6 +4,7 @@ namespace PhpCoveralls\Tests\Component\Log;
 
 use PhpCoveralls\Component\Log\ConsoleLogger;
 use PhpCoveralls\Tests\ProjectTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**
@@ -13,6 +14,8 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class ConsoleLoggerTest extends ProjectTestCase
 {
+    use ProphecyTrait;
+    
     /**
      * @test
      */


### PR DESCRIPTION
Since prophecy-support in phpunit is deprecated, and will be remove in phpunit 10, this PR add prophecy-support via phpspec/prophecy-phpunit.