### PR TITLE
Support root directory in git commands

### DIFF
--- a/src/Bundle/CoverallsBundle/Api/Jobs.php
+++ b/src/Bundle/CoverallsBundle/Api/Jobs.php
@@ -73,7 +73,7 @@ class Jobs extends CoverallsApi
      */
     public function collectGitInfo()
     {
-        $command = new GitCommand();
+        $command = new GitCommand(null, $this->getConfiguration()->getRootDir() ?: '.');
         $gitCollector = new GitInfoCollector($command);
 
         $this->jsonFile->setGit($gitCollector->collect());

--- a/src/Component/System/Git/GitCommand.php
+++ b/src/Component/System/Git/GitCommand.php
@@ -17,9 +17,16 @@ class GitCommand
      */
     private $executor;
 
-    public function __construct(SystemCommandExecutorInterface $executor = null)
+    /**
+     * @var string
+     */
+    private $rootDir;
+
+
+    public function __construct(SystemCommandExecutorInterface $executor = null, $rootDir = '.' )
     {
         $this->executor = $executor ? $executor : new SystemCommandExecutor();
+        $this->rootDir = $rootDir;
     }
 
     /**
@@ -29,7 +36,7 @@ class GitCommand
      */
     public function getBranches()
     {
-        return $this->executor->execute('git branch');
+        return $this->executor->execute('git -C ' . $this->rootDir . ' branch');
     }
 
     /**
@@ -39,7 +46,7 @@ class GitCommand
      */
     public function getHeadCommit()
     {
-        return $this->executor->execute("git log -1 --pretty=format:'%H%n%aN%n%ae%n%cN%n%ce%n%s'");
+        return $this->executor->execute("git -C " . $this->rootDir . " log -1 --pretty=format:'%H%n%aN%n%ae%n%cN%n%ce%n%s'");
     }
 
     /**
@@ -49,6 +56,6 @@ class GitCommand
      */
     public function getRemotes()
     {
-        return $this->executor->execute('git remote -v');
+        return $this->executor->execute('git -C ' . $this->rootDir . ' remote -v');
     }
 }


### PR DESCRIPTION
php-coverage fetches the wrong GIT information if you have the following directory structure:
```
appdir/.git/
appdir/extensions/myextension/.git/
```
In that case, the last GIT commit from `appdir/.git/` is added to the JSON file and coveralls.io can't show the source code. Instead, it displays:
```
The commit SHA "8bac75ac740f8f7f54f51b49f3740cc3ea935b19" was not found in your repository,
so the file cannot be loaded. This may be because you posted from a local development environment,
or your CI created an ephemeral commit.
```
This PR adds support for the root directory parameter in GIT commands, e.g. `git -C extensions/myextension log`.