### PR TITLE
PHP 8.2 | Fix deprecated embedded variables in text strings

### DIFF
--- a/src/Bundle/CoverallsBundle/Config/Configurator.php
+++ b/src/Bundle/CoverallsBundle/Config/Configurator.php
@@ -149,7 +149,7 @@ class Configurator
 
         // validate
         if (count($paths) === 0) {
-            throw new InvalidConfigurationException("coverage_clover XML file is not readable: ${path}");
+            throw new InvalidConfigurationException("coverage_clover XML file is not readable: {$path}");
         }
 
         return $paths;
@@ -220,14 +220,14 @@ class Configurator
         $realFilePath = $file->getRealPath($realpath, $rootDir);
 
         if ($realFilePath !== false && !$file->isRealFileWritable($realFilePath)) {
-            throw new InvalidConfigurationException("json_path is not writable: ${realFilePath}");
+            throw new InvalidConfigurationException("json_path is not writable: {$realFilePath}");
         }
 
         // validate parent dir
         $realDir = $file->getRealDir($realpath, $rootDir);
 
         if (!$file->isRealDirWritable($realDir)) {
-            throw new InvalidConfigurationException("json_path is not writable: ${realFilePath}");
+            throw new InvalidConfigurationException("json_path is not writable: {$realFilePath}");
         }
 
         return $realpath;


### PR DESCRIPTION
PHP 8.2 will deprecate two of the four currently supported syntaxes for embedding variables in double quoted text string/heredocs.

This libery contains three uses of embedded variables using braces after the dollar sign (`"${foo}"`), which is one of the deprecated forms.

This commit fixes all three.

Refs:
* https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation