### PR TITLE
MetricsTest: fix tests failing on imprecise floats

### DIFF
--- a/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php
@@ -83,7 +83,7 @@ class MetricsTest extends ProjectTestCase
     {
         $object = new Metrics($this->coverage);
 
-        $this->assertSame(200 / 3, $object->getLineCoverage());
+        $this->assertWithDelta(200 / 3, $object->getLineCoverage(), 0.0000000000001);
     }
 
     // merge()
@@ -99,7 +99,7 @@ class MetricsTest extends ProjectTestCase
 
         $this->assertSame(3, $object->getStatements());
         $this->assertSame(2, $object->getCoveredStatements());
-        $this->assertSame(200 / 3, $object->getLineCoverage());
+        $this->assertWithDelta(200 / 3, $object->getLineCoverage(), 0.0000000000001);
     }
 
     /**
@@ -113,7 +113,7 @@ class MetricsTest extends ProjectTestCase
 
         $this->assertSame(6, $object->getStatements());
         $this->assertSame(4, $object->getCoveredStatements());
-        $this->assertSame(400 / 6, $object->getLineCoverage());
+        $this->assertWithDelta(400 / 6, $object->getLineCoverage(), 0.0000000000001);
     }
 
     protected function legacySetUp()
@@ -122,5 +122,16 @@ class MetricsTest extends ProjectTestCase
         $this->coverage[1] = 1;
         $this->coverage[3] = 1;
         $this->coverage[4] = 0;
+    }
+
+    private function assertWithDelta($expected, $actual, $delta, $message = '')
+    {
+        if (method_exists(ProjectTestCase::class, 'assertEqualsWithDelta')) {
+            parent::assertEqualsWithDelta($expected, $actual, $delta, $message);
+
+            return;
+        }
+
+        static::assertEquals($expected, $actual, $message, $delta);
     }
 }


### PR DESCRIPTION
This solves the following test failures (`master` is currently failing on a number of PHP versions):
```
1) PhpCoveralls\Tests\Bundle\CoverallsBundle\Entity\MetricsTest::shouldHaveLineCoverageOnConstructionWithCoverage
Failed asserting that 66.66666666666666 is identical to 66.66666666666667.

/home/runner/work/php-coveralls/php-coveralls/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php:86
phpvfscomposer:///home/runner/work/php-coveralls/php-coveralls/vendor/phpunit/phpunit/phpunit:97

2) PhpCoveralls\Tests\Bundle\CoverallsBundle\Entity\MetricsTest::shouldMergeThatWithEmptyMetrics
Failed asserting that 66.66666666666666 is identical to 66.66666666666667.

/home/runner/work/php-coveralls/php-coveralls/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php:102
phpvfscomposer:///home/runner/work/php-coveralls/php-coveralls/vendor/phpunit/phpunit/phpunit:97

3) PhpCoveralls\Tests\Bundle\CoverallsBundle\Entity\MetricsTest::shouldMergeThat
Failed asserting that 66.66666666666666 is identical to 66.66666666666667.

/home/runner/work/php-coveralls/php-coveralls/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php:116
phpvfscomposer:///home/runner/work/php-coveralls/php-coveralls/vendor/phpunit/phpunit/phpunit:97
```

Note: this adds a polyfill to handle a new PHPUnit assertion. Alternatively, you could choose to add the [PHPUnit Polyfills](https://github.com/Yoast/PHPUnit-Polyfills) as a dependency instead. This would allow to use the _official_ method name from PHPUnit.

Refs:
* https://floating-point-gui.de/
* https://phpunit.readthedocs.io/en/9.5/assertions.html#assertequalswithdelta
* https://github.com/Yoast/PHPUnit-Polyfills