### PR TITLE
PHP 8.1 | Fix "passing null to non-nullable" deprecations (tests only)

### DIFF
--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -590,6 +590,7 @@ class JobsTest extends ProjectTestCase
     protected function createConfiguration()
     {
         $config = new Configuration();
+        $config->setRootDir('');
 
         return $config->addCloverXmlPath($this->cloverXmlPath);
     }


### PR DESCRIPTION
Without a root directory, the `rtrim()` at the start of the `CloverXmlCoverageCollector::collect()` method will throw a `rtrim(): Passing null to parameter #1 ($string) of type string is deprecated` deprecation notice.

Setting the `Configuration::$rootDir` to an empty string bypasses this for these tests.