### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/src/Bundle/CoverallsBundle/Config/Configurator.php
+++ b/src/Bundle/CoverallsBundle/Config/Configurator.php
@@ -149,7 +149,7 @@ class Configurator
 
         // validate
         if (count($paths) === 0) {
-            throw new InvalidConfigurationException("coverage_clover XML file is not readable: ${path}");
+            throw new InvalidConfigurationException("coverage_clover XML file is not readable: {$path}");
         }
 
         return $paths;
@@ -220,14 +220,14 @@ class Configurator
         $realFilePath = $file->getRealPath($realpath, $rootDir);
 
         if ($realFilePath !== false && !$file->isRealFileWritable($realFilePath)) {
-            throw new InvalidConfigurationException("json_path is not writable: ${realFilePath}");
+            throw new InvalidConfigurationException("json_path is not writable: {$realFilePath}");
         }
 
         // validate parent dir
         $realDir = $file->getRealDir($realpath, $rootDir);
 
         if (!$file->isRealDirWritable($realDir)) {
-            throw new InvalidConfigurationException("json_path is not writable: ${realFilePath}");
+            throw new InvalidConfigurationException("json_path is not writable: {$realFilePath}");
         }
 
         return $realpath;


### PR DESCRIPTION
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes all three of such occurrences in `php-coveralls/php-coveralls` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)