### PR TITLE
Upgrade PHAR generation to Box 4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,34 +113,28 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v3
 
-            -   name: Setup PHP to install dependencies
+            -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 5.5
-                    ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
+                    php-version: 8.1
+                    extensions: phar, openssl, sodium
                     coverage: none
+                    ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
                     # Autoload files generated with Composer 2.3+ are not compatible with PHP < 7.0.
                     tools: composer:2.2
+
+            -   name: Set Composer platform
+                run: composer config platform.php 5.5.0
 
             -   name: Install Composer dependencies
                 uses: ramsey/composer-install@v2
                 with:
                     composer-options: "--no-dev --optimize-autoloader"
 
-            -   name: Setup PHP to generate the PHAR
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: 8.1
-                    extensions: exif, phar, openssl, sodium
-                    coverage: none
-                    ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
-                    # Autoload files generated with Composer 2.3+ are not compatible with PHP < 7.0.
-                    tools: composer:2.2
-
             # Note: do NOT turn on the requirement checker in the box config as it is no longer
             # compatible with PHP < 7.2.
             -   name: Install Box
-                run: wget https://github.com/humbug/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
+                run: wget https://github.com/humbug/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar
 
             -   name: Validate configuration
                 run: php box.phar validate -i box.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,16 +113,79 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@v3
 
+            -   name: Setup PHP to install dependencies
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 5.5
+                    ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
+                    coverage: none
+                    # Autoload files generated with Composer 2.3+ are not compatible with PHP < 7.0.
+                    tools: composer:2.2
+
+            -   name: Install Composer dependencies
+                uses: ramsey/composer-install@v2
+                with:
+                    composer-options: "--no-dev --optimize-autoloader"
+
+            -   name: Setup PHP to generate the PHAR
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.1
+                    extensions: exif, phar, openssl, sodium
+                    coverage: none
+                    ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
+                    # Autoload files generated with Composer 2.3+ are not compatible with PHP < 7.0.
+                    tools: composer:2.2
+
+            # Note: do NOT turn on the requirement checker in the box config as it is no longer
+            # compatible with PHP < 7.2.
+            -   name: Install Box
+                run: wget https://github.com/humbug/box/releases/latest/download/box.phar -O box.phar && chmod 0755 box.phar && pwd
+
+            -   name: Validate configuration
+                run: php box.phar validate -i box.json
+
+            -   name: Building binary...
+                run: php box.phar compile -v --config=box.json
+
+            -   name: Show info about the build phar
+                run: php box.phar info -l ./build/artifacts/php-coveralls.phar
+
+            -   name: Upload the Phar artifact
+                uses: actions/upload-artifact@v3
+                with:
+                    name: php-coveralls-phar
+                    path: ./build/artifacts/php-coveralls.phar
+                    retention-days: 30
+
+    test-phar:
+        needs: build-phar
+        name: "Test Phar PHP ${{ matrix.php }}"
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    -   php: '5.5'
+                    -   php: '7.2'
+                    -   php: '8.0'
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v3
+
+            -   name: Download the Phar artifact
+                uses: actions/download-artifact@v3
+                with:
+                    name: php-coveralls-phar
+
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 7.0
+                    php-version: ${{ matrix.php }}
+                    ini-values: error_reporting=-1, display_errors=On, zend.assertions=1
                     coverage: none
 
-            -   name: Build PHAR
-                run: |
-                    curl -LSs https://box-project.github.io/box2/installer.php | php
-                    composer config platform.php 2> /dev/null || composer config platform.php 5.5.0
-                    composer update --no-dev --no-interaction --optimize-autoloader --no-interaction --no-progress
-                    php -d phar.readonly=false box.phar build
-                    ./build/artifacts/php-coveralls.phar --version
+            -   name: Test the Phar is functional
+                run: php php-coveralls.phar --version

--- a/box.json
+++ b/box.json
@@ -1,11 +1,15 @@
 {
   "alias": "php-coveralls.phar",
+  "base-path": null,
   "chmod": "0755",
-  "directories": ["src"],
-  "compactors": [
-    "Herrera\\Box\\Compactor\\Php"
+  "directories": [
+    "bin",
+    "src"
   ],
-  "extract": true,
+  "check-requirements": false,
+  "compactors": [
+    "KevinGH\\Box\\Compactor\\Php"
+  ],
   "files": [
     "LICENSE"
   ],


### PR DESCRIPTION
Box 2 is no longer maintained and will not be made compatible with more recent PHP versions.

#### Config

* Updated the Box configuration for changes made in Box 3 and 4.
* Explicitly set `check-requirements` to `false` as the requirements checker in Box 4 is not compatible with PHP < 7.2.

#### GH Actions workflows

* Install the dependencies on the minimum supported PHP version.
* Updated the PHP setup to have the necessary PHP version, extensions and ini config needed to generate the PHAR with Box 4.
* Explicitly set the required Composer version to `2.2` as the autoload files generated with Composer 2.3+ are not compatible with PHP 5.5.
* Updated the PHAR generation command.
* Added validation and debug steps for the PHAR generation.
* Added a step to upload the Phar as a build artifact. The PHAR files uploaded in this way will remain accessible for 60 days.
* Added a job to test that the Phar is minimally functional against the high/middle/low supported PHP versions.

Refs:
* https://github.com/box-project/box/blob/master/UPGRADE.md
* https://github.com/box-project/box/blob/master/doc/configuration.md
* https://github.com/box-project/box/blob/master/doc/requirement-checker.md#requirements-checker
* https://github.com/box-project/box/issues/656#issuecomment-1164471935

Fixes #350