### PR TITLE
Adds support for psr/log v3 (breaking changes so new major version suggested)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,34 +12,11 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    -   php: '5.5'
+                    -   php: '8.1'
                         os: ubuntu-latest
-                        composer-flags: '--prefer-lowest'
-                        coverage: 'xdebug'
-                    -   php: '5.5'
-                        os: ubuntu-latest
-                        symfony: '^3.0'
-                    -   php: '5.5'
-                        os: windows-latest
-                        coverage: 'xdebug'
-                    -   php: '5.6'
-                        os: ubuntu-latest
-                    -   php: '7.0'
-                        os: ubuntu-latest
-                    -   php: '7.1'
-                        os: ubuntu-latest
-                        symfony: '^4.0'
-                    -   php: '7.2'
-                        os: ubuntu-latest
-                        symfony: '^5.0'
-                    -   php: '7.3'
-                        os: ubuntu-latest
-                    -   php: '7.4'
-                        os: ubuntu-latest
-                    -   php: '7.4'
-                        os: windows-latest
+                        symfony: '^6.0'
                         coverage: 'pcov'
-                    -   php: '8.0'
+                    -   php: '8.2'
                         os: ubuntu-latest
                         symfony: '^6.0'
                         coverage: 'pcov'
@@ -120,11 +97,7 @@ jobs:
                     extensions: phar, openssl, sodium
                     coverage: none
                     ini-values: phar.readonly=Off, error_reporting=-1, display_errors=On, zend.assertions=1
-                    # Autoload files generated with Composer 2.3+ are not compatible with PHP < 7.0.
-                    tools: composer:2.2
-
-            -   name: Set Composer platform
-                run: composer config platform.php 5.5.0
+                    tools: composer:v2
 
             -   name: Install Composer dependencies
                 uses: ramsey/composer-install@v2
@@ -161,9 +134,8 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    -   php: '5.5'
-                    -   php: '7.2'
-                    -   php: '8.0'
+                    -   php: '8.1'
+                    -   php: '8.2'
 
         steps:
             -   name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -30,19 +30,19 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0 || ^8.0",
+        "php": ">=8.1",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "guzzlehttp/guzzle": "^6.0 || ^7.0",
-        "psr/log": "^1.0 || ^2.0",
-        "symfony/config": "^2.1 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/console": "^2.1 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/stopwatch": "^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/yaml": "^2.0.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
+        "guzzlehttp/guzzle": "^7.0",
+        "psr/log": "^2.0 || ^3.0",
+        "symfony/config": "^6.0",
+        "symfony/console": "^6.0",
+        "symfony/stopwatch": "^6.0",
+        "symfony/yaml": "^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.4.3 || ^6.0 || ^7.0 || >=8.0 <8.5.29 || >=9.0 <9.5.23",
-        "sanmai/phpunit-legacy-adapter": "^6.1 || ^8.0"
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": ">=9.3"
     },
     "suggest": {
         "symfony/http-kernel": "Allows Symfony integration"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.2/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     beStrictAboutChangesToGlobalState="true"
@@ -31,20 +31,24 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>./src</directory>
-            <exclude>
-                <directory>./build</directory>
-                <directory>./composer</directory>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+
+        <exclude>
+            <directory>./build</directory>
+            <directory>./composer</directory>
+            <directory>./tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
 
     <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+        <junit outputFile="build/logs/junit.xml"/>
     </logging>
 </phpunit>

--- a/src/Bundle/CoverallsBundle/Repository/JobsRepository.php
+++ b/src/Bundle/CoverallsBundle/Repository/JobsRepository.php
@@ -7,7 +7,7 @@ use PhpCoveralls\Bundle\CoverallsBundle\Api\Jobs;
 use PhpCoveralls\Bundle\CoverallsBundle\Config\Configuration;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\JsonFile;
 use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerAwareTrait;
 
 /**
  * Jobs API client.
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
  */
 class JobsRepository implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
     /**
      * Jobs API.
      *
@@ -31,13 +32,6 @@ class JobsRepository implements LoggerAwareInterface
      * @var \PhpCoveralls\Bundle\CoverallsBundle\Config\Configuration
      */
     protected $config;
-
-    /**
-     * Logger.
-     *
-     * @var \Psr\Log\LoggerInterface
-     */
-    protected $logger;
 
     /**
      * Constructor.
@@ -77,18 +71,6 @@ class JobsRepository implements LoggerAwareInterface
 
             return false;
         }
-    }
-
-    // LoggerAwareInterface
-
-    /**
-     * {@inheritdoc}
-     *
-     * @see \Psr\Log\LoggerAwareInterface::setLogger()
-     */
-    public function setLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
     }
 
     // internal method
@@ -155,7 +137,7 @@ class JobsRepository implements LoggerAwareInterface
 
         $this->api->dumpJsonFile();
 
-        $filesize = number_format(filesize($jsonPath) / 1024, 2); // kB
+        $filesize = is_null($jsonPath) ? 0 : number_format(filesize($jsonPath) / 1024, 2); // kB
         $this->logger->info(sprintf('File size: <info>%s</info> kB', $filesize));
 
         return $this;

--- a/src/Component/Log/ConsoleLogger.php
+++ b/src/Component/Log/ConsoleLogger.php
@@ -32,7 +32,7 @@ class ConsoleLogger extends AbstractLogger
      *
      * @see \Psr\Log\LoggerInterface::log()
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, string|\Stringable $message, array $context = []) : void
     {
         $this->output->writeln($message);
     }

--- a/tests/Bundle/CoverallsBundle/Api/JobsTest.php
+++ b/tests/Bundle/CoverallsBundle/Api/JobsTest.php
@@ -490,12 +490,12 @@ final class JobsTest extends ProjectTestCase
         ;
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
-    protected function legacyTearDown()
+    protected function tearDown() : void
     {
         $this->rmFile($this->jsonPath);
         $this->rmFile($this->cloverXmlPath);

--- a/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CiEnvVarsCollectorTest.php
@@ -464,7 +464,7 @@ final class CiEnvVarsCollectorTest extends ProjectTestCase
         static::assertArrayHasKey('COVERALLS_REPO_TOKEN', $readEnv);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }

--- a/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
+++ b/tests/Bundle/CoverallsBundle/Collector/CloverXmlCoverageCollectorTest.php
@@ -160,7 +160,7 @@ final class CloverXmlCoverageCollectorTest extends ProjectTestCase
         $this->assertSourceFileTest2UnderRootDir($sourceFiles[$path2]);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
 

--- a/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
+++ b/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
@@ -196,12 +196,12 @@ final class CoverallsJobsCommandTest extends ProjectTestCase
         static::assertSame(0, $actual);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
-    protected function legacyTearDown()
+    protected function tearDown() : void
     {
         $this->rmFile($this->cloverXmlPath);
         $this->rmFile($this->jsonPath);

--- a/tests/Bundle/CoverallsBundle/Config/ConfigurationTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfigurationTest.php
@@ -424,7 +424,7 @@ final class ConfigurationTest extends ProjectTestCase
         static::assertSame($expected, $this->object->getEnv());
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->object = new Configuration();
     }

--- a/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
+++ b/tests/Bundle/CoverallsBundle/Config/ConfiguratorTest.php
@@ -377,7 +377,7 @@ final class ConfiguratorTest extends ProjectTestCase
         $this->object->load($path, $this->rootDir);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
 
@@ -386,7 +386,7 @@ final class ConfiguratorTest extends ProjectTestCase
         $this->object = new Configurator();
     }
 
-    protected function legacyTearDown()
+    protected function tearDown() : void
     {
         $this->rmFile($this->cloverXmlPath);
         $this->rmFile($this->cloverXmlPath1);

--- a/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
+++ b/tests/Bundle/CoverallsBundle/Console/ApplicationTest.php
@@ -44,12 +44,12 @@ final class ApplicationTest extends ProjectTestCase
         static::assertSame(0, $actual);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
 
-    protected function legacyTearDown()
+    protected function tearDown() : void
     {
         $this->rmFile($this->cloverXmlPath);
         $this->rmFile($this->jsonPath);

--- a/tests/Bundle/CoverallsBundle/Entity/Git/CommitTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/CommitTest.php
@@ -224,7 +224,7 @@ final class CommitTest extends ProjectTestCase
         static::assertSame(json_encode($expected), (string) $this->object);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->object = new Commit();
     }

--- a/tests/Bundle/CoverallsBundle/Entity/Git/GitTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/GitTest.php
@@ -84,7 +84,7 @@ final class GitTest extends ProjectTestCase
         static::assertSame(json_encode($expected), (string) $this->object);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->branchName = 'branch_name';
         $this->commit = $this->createCommit();

--- a/tests/Bundle/CoverallsBundle/Entity/Git/RemoteTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/Git/RemoteTest.php
@@ -108,7 +108,7 @@ final class RemoteTest extends ProjectTestCase
         static::assertSame(json_encode($expected), (string) $this->object);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->object = new Remote();
     }

--- a/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/JsonFileTest.php
@@ -732,7 +732,7 @@ final class JsonFileTest extends ProjectTestCase
         static::assertNotContains('AbstractClass.php', $filenames);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
 

--- a/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/MetricsTest.php
@@ -118,7 +118,7 @@ final class MetricsTest extends ProjectTestCase
         $this->assertWithDelta(400 / 6, $object->getLineCoverage(), 0.0000000000001);
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->coverage = array_fill(0, 5, null);
         $this->coverage[1] = 1;

--- a/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
+++ b/tests/Bundle/CoverallsBundle/Entity/SourceFileTest.php
@@ -142,7 +142,7 @@ final class SourceFileTest extends ProjectTestCase
         static::assertSame(100, $this->object->reportLineCoverage());
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
 

--- a/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
+++ b/tests/Bundle/CoverallsBundle/Repository/JobsRepositoryTest.php
@@ -10,6 +10,7 @@ use PhpCoveralls\Bundle\CoverallsBundle\Entity\Metrics;
 use PhpCoveralls\Bundle\CoverallsBundle\Entity\SourceFile;
 use PhpCoveralls\Bundle\CoverallsBundle\Repository\JobsRepository;
 use PhpCoveralls\Tests\ProjectTestCase;
+use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
@@ -166,7 +167,7 @@ final class JobsRepositoryTest extends ProjectTestCase
         static::assertFalse($object->persist());
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->setUpDir(realpath(__DIR__ . '/../../..'));
     }
@@ -229,8 +230,8 @@ final class JobsRepositoryTest extends ProjectTestCase
     protected function createLoggerMock()
     {
         $logger = $this->prophesize(NullLogger::class);
-        $logger->info();
-        $logger->error();
+        $logger->info(Argument::any());
+        $logger->error(Argument::any());
 
         return $logger->reveal();
     }

--- a/tests/Component/File/PathTest.php
+++ b/tests/Component/File/PathTest.php
@@ -448,7 +448,7 @@ final class PathTest extends ProjectTestCase
         static::assertTrue($this->object->isRealDirWritable($path));
     }
 
-    protected function legacySetUp()
+    protected function setUp() : void
     {
         $this->existingFile = __DIR__ . '/existing.txt';
         $this->unreadablePath = __DIR__ . '/unreadable.txt';
@@ -458,7 +458,7 @@ final class PathTest extends ProjectTestCase
         $this->object = new Path();
     }
 
-    protected function legacyTearDown()
+    protected function tearDown() : void
     {
         $this->rmFile($this->existingFile);
         $this->rmFile($this->unreadablePath);

--- a/tests/ProjectTestCase.php
+++ b/tests/ProjectTestCase.php
@@ -2,10 +2,12 @@
 
 namespace PhpCoveralls\Tests;
 
-use LegacyPHPUnit\TestCase;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 abstract class ProjectTestCase extends TestCase
 {
+    use ProphecyTrait;
     /**
      * @var string
      */


### PR DESCRIPTION
This PR adds support for psr/log v3.

As it needs PHP 8.1+ this PR drops as well previous PHP versions.

It also takes advantage to migrate all PHPUnit tests to be compatible with PHPUnit 9.3+ and removes `anmai/phpunit-legacy-adapter`. Migrating tests needed `phpspec/prophecy-phpunit` as it will be deprecated from PHPUnit 10.0.

As it breaks backwards compatibility, a major version release is suggested.