### PR TITLE
Fix PHP 8.1 compatibility

### DIFF
--- a/src/Bundle/CoverallsBundle/Repository/JobsRepository.php
+++ b/src/Bundle/CoverallsBundle/Repository/JobsRepository.php
@@ -155,7 +155,10 @@ class JobsRepository implements LoggerAwareInterface
 
         $this->api->dumpJsonFile();
 
-        $filesize = number_format(filesize($jsonPath) / 1024, 2); // kB
+        $filesize = 0;
+        if (\is_string($jsonPath) && file_exists($jsonPath)) {
+            $filesize = number_format(filesize($jsonPath) / 1024, 2); // kB
+        }
         $this->logger->info(sprintf('File size: <info>%s</info> kB', $filesize));
 
         return $this;


### PR DESCRIPTION
The tests were failing on PHP 8.1 due to a `file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated` notice coming from the `JobsRepository::dumpJsonFile()` method.

While it would probably be unlikely for this error condition ever to be hit in a real life situation, it is something which is likely to happen in the tests and well, a little defensive coding goes a long way.

With this fix in place, the tests now pass on PHP 8.1 and PHP 8.2 and compatibility with both can be declared. :tada: