### PR TITLE
README: fix broken badge and mention GH Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 php-coveralls
 =============
 
-[![Build Status](https://travis-ci.org/php-coveralls/php-coveralls.svg?branch=master)](https://travis-ci.org/php-coveralls/php-coveralls)
+[![Static Code Analysis](https://github.com/php-coveralls/php-coveralls/actions/workflows/static-code-analysis.yml/badge.svg)](https://github.com/php-coveralls/php-coveralls/actions/workflows/static-code-analysis.yml)
+[![CI](https://github.com/php-coveralls/php-coveralls/actions/workflows/ci.yml/badge.svg)](https://github.com/php-coveralls/php-coveralls/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/php-coveralls/php-coveralls/badge.png?branch=master)](https://coveralls.io/r/php-coveralls/php-coveralls)
 
 [![Latest Stable Version](https://poser.pugx.org/php-coveralls/php-coveralls/v/stable.png)](https://packagist.org/packages/php-coveralls/php-coveralls)
@@ -13,7 +14,7 @@ PHP client library for [Coveralls](https://coveralls.io).
 
 - PHP 5.5+ for 2.x or 5.3+ for 1.x
 - On [GitHub](https://github.com/)
-- Building on [Travis CI](http://travis-ci.org/), [CircleCI](https://circleci.com/), [Jenkins](http://jenkins-ci.org/) or [Codeship](https://www.codeship.io/)
+- Building on [Travis CI](http://travis-ci.org/), [CircleCI](https://circleci.com/), [Jenkins](http://jenkins-ci.org/), [Codeship](https://www.codeship.io/) or [GitHub Actions](https://github.com/features/actions)
 - Testing by [PHPUnit](https://github.com/sebastianbergmann/phpunit/) or other testing framework that can generate clover style coverage report
 
 # Installation


### PR DESCRIPTION
The build status badge in README was broken as it still pointed to Travis, while CI has been moved to GH Actions.

This commit fixes this by replacing the Travis badge with two badges for the GH Actions workflows.

And while GH Actions is already mentioned lower down in the README with a code example of how to use PHP Coveralls, it wasn't mentioned in the "Prerequisites" at the top of the README. Fixed now.

Before:
![image](https://user-images.githubusercontent.com/663378/236208671-f6b4b70a-d6fd-4caa-9848-ac75bff1d3eb.png)

After:
![image](https://user-images.githubusercontent.com/663378/236208793-536cc72e-720e-4362-abae-9c5610500a09.png)
