### PR TITLE
GH Actions/CI: run the test suite against PHP 8.1, 8.2 and 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,29 @@ jobs:
                         os: ubuntu-latest
                     -   php: '7.4'
                         os: ubuntu-latest
-                    -   php: '7.4'
-                        os: windows-latest
-                        coverage: 'pcov'
                     -   php: '8.0'
                         os: ubuntu-latest
                         symfony: '^6.0'
+                    -   php: '8.1'
+                        os: ubuntu-latest
+                        symfony: '^6.0'
+                    -   php: '8.2'
+                        os: ubuntu-latest
+                        symfony: '^6.0'
                         coverage: 'pcov'
+                    -   php: '8.2'
+                        os: ubuntu-latest
+                        symfony: '^6.0'
+                        coverage: 'xdebug'
+                    -   php: '8.2'
+                        os: windows-latest
+                        symfony: '^6.0'
+                        coverage: 'pcov'
+                    -   php: '8.3'
+                        os: ubuntu-latest
+                        symfony: '^6.0'
+
+        continue-on-error: ${{ matrix.php == '8.3' }}
 
         steps:
             -   name: Checkout source
@@ -79,11 +95,11 @@ jobs:
                 run: composer config extra.symfony.require ${{ matrix.symfony }}
 
             -   name: Update composer dependencies
-                if: matrix.php != '8.2'
+                if: matrix.php != '8.3'
                 run: composer update -o --no-interaction --no-progress ${{ matrix.composer-flags }}
 
             -   name: "Update composer dependencies (PHP 8.2, ignore platform)"
-                if: matrix.php == '8.2'
+                if: matrix.php == '8.3'
                 run: composer update -o --no-interaction --no-progress ${{ matrix.composer-flags }} --ignore-platform-req=php+
 
             -   name: Run test suite
@@ -164,6 +180,9 @@ jobs:
                     -   php: '5.5'
                     -   php: '7.2'
                     -   php: '8.0'
+                    -   php: '8.3'
+
+        continue-on-error: ${{ matrix.php == '8.3' }}
 
         steps:
             -   name: Checkout

--- a/src/Bundle/CoverallsBundle/Repository/JobsRepository.php
+++ b/src/Bundle/CoverallsBundle/Repository/JobsRepository.php
@@ -155,7 +155,10 @@ class JobsRepository implements LoggerAwareInterface
 
         $this->api->dumpJsonFile();
 
-        $filesize = number_format(filesize($jsonPath) / 1024, 2); // kB
+        $filesize = 0;
+        if (\is_string($jsonPath) && file_exists($jsonPath)) {
+            $filesize = number_format(filesize($jsonPath) / 1024, 2); // kB
+        }
         $this->logger->info(sprintf('File size: <info>%s</info> kB', $filesize));
 
         return $this;


### PR DESCRIPTION
⚠️ This PR depends on PR #361 and can be marked "Ready for review" (and rebased) once PR #361 has been merged.

---

PR #361 should fix the remaining (known) PHP 8.1 error.

Once that PR has been merged, the CI runs against PHP 8.1, 8.2 and 8.3 should pass.

To that end, I'm adding builds against PHP 8.1, 8.2 and 8.3.

I'm also moving the code coverage recording from PHP 7.4 to PHP 8.2 to ensure high/low PHP is measured and adding an extra variant with `Xdebug` on high PHP too.

As PHP 8.3 is still in flux, builds against it are still allowed to fail.