### PR TITLE
docs: remove duplicated word "other"

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ php-coveralls can use optional `.coveralls.yml` file to configure options. This 
 
 Following options can be used for php-coveralls.
 
-- `entry_point`: Used to specify API endpoint for sending reports. Useful when using self-hosted coveralls or other other, similar service (eg opencov). Default is `https://coveralls.io`.
+- `entry_point`: Used to specify API endpoint for sending reports. Useful when using self-hosted coveralls or other, similar service (eg opencov). Default is `https://coveralls.io`.
 - `coverage_clover`: Used to specify the path to `clover.xml`. Default is `build/logs/clover.xml`
 - `json_path`: Used to specify where to output `json_file` that will be uploaded to Coveralls API. Default is `build/logs/coveralls-upload.json`.
 


### PR DESCRIPTION
It is a silly change, but it will make me a contributor and I will be able to work on https://github.com/php-coveralls/php-coveralls/pull/379 faster.