### PR TITLE
Add support for Symfony 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
                     -   php: '8.4'
                         os: macos-latest
                         coverage: 'pcov'
+                    -   php: '8.4'
+                        os: ubuntu-latest
+                        symfony: '^8.0'
+                        composer-stability: 'beta'
 
         steps:
             -   name: Checkout source
@@ -52,6 +56,10 @@ jobs:
                     php-version: ${{ matrix.php }}
                     ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, log_errors_max_len=0
                     coverage: ${{ matrix.coverage || 'none' }}
+
+            -   name: Configure composer stability
+                if: matrix.composer-stability
+                run: composer config minimum-stability ${{ matrix.composer-stability }}
 
             -   name: "Disallow Symfony Flex to run as a Composer plugin (global)"
                 run: composer global config allow-plugins.symfony/flex false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
                         os: ubuntu-latest
                     -   php: '8.4'
                         os: ubuntu-latest
-                        symfony: '^7.0' # update to 8.0 when available
+                        symfony: '^8.0'
+                        composer-stability: 'beta'
                     -   php: '8.4'
                         os: ubuntu-latest
                         coverage: 'pcov'
@@ -41,10 +42,6 @@ jobs:
                     -   php: '8.4'
                         os: macos-latest
                         coverage: 'pcov'
-                    -   php: '8.4'
-                        os: ubuntu-latest
-                        symfony: '^8.0'
-                        composer-stability: 'beta'
 
         steps:
             -   name: Checkout source

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,10 @@
         "ext-simplexml": "*",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "psr/log": "^1.0 || ^2.0",
-        "symfony/config": "^5.4 || ^6.4 || ^7.0",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
-        "symfony/stopwatch": "^5.4 || ^6.4 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.4 || ^7.0"
+        "symfony/config": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/console": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/stopwatch": "^5.4 || ^6.4 || ^7.0 || ^8.0",
+        "symfony/yaml": "^5.4 || ^6.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpspec/prophecy-phpunit": "^2.4",

--- a/src/Bundle/CoverallsBundle/Command/CoverallsJobsCommand.php
+++ b/src/Bundle/CoverallsBundle/Command/CoverallsJobsCommand.php
@@ -62,7 +62,7 @@ class CoverallsJobsCommand extends Command
     /**
      * @see \Symfony\Component\Console\Command\Command::configure()
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('coveralls:v1:jobs')

--- a/src/Bundle/CoverallsBundle/Console/ApplicationFactory.php
+++ b/src/Bundle/CoverallsBundle/Console/ApplicationFactory.php
@@ -42,13 +42,13 @@ class ApplicationFactory
 
         if (false === class_exists(SingleCommandApplication::class)) {
             $application = new CoverallsApplication(self::APP_NAME, self::APP_VERSION);
-            $application->add($command);
+            method_exists($application, 'addCommand') ? $application->addCommand($command) : $application->add($command);
 
             return $application;
         }
 
         $application = new Application(self::APP_NAME, self::APP_VERSION);
-        $application->add($command);
+        method_exists($application, 'addCommand') ? $application->addCommand($command) : $application->add($command);
         $application->setDefaultCommand($command->getName(), true);
 
         return $application;

--- a/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
+++ b/tests/Bundle/CoverallsBundle/Command/CoverallsJobsCommandTest.php
@@ -42,7 +42,7 @@ final class CoverallsJobsCommandTest extends ProjectTestCase
         $command->setRootDir($this->rootDir);
 
         $app = new Application();
-        $app->add($command);
+        method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
 
         $command = $app->find('coveralls:v1:jobs');
         $commandTester = new CommandTester($command);
@@ -90,7 +90,7 @@ final class CoverallsJobsCommandTest extends ProjectTestCase
         $command->setRootDir($this->logsDir); // Wrong rootDir.
 
         $app = new Application();
-        $app->add($command);
+        method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
 
         $command = $app->find('coveralls:v1:jobs');
         $commandTester = new CommandTester($command);
@@ -122,7 +122,7 @@ final class CoverallsJobsCommandTest extends ProjectTestCase
         $command->setRootDir($this->logsDir); // Wrong rootDir.
 
         $app = new Application();
-        $app->add($command);
+        method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
 
         $command = $app->find('coveralls:v1:jobs');
         $commandTester = new CommandTester($command);
@@ -158,7 +158,7 @@ final class CoverallsJobsCommandTest extends ProjectTestCase
         $command->setRootDir($this->rootDir);
 
         $app = new Application();
-        $app->add($command);
+        method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
 
         $command = $app->find('coveralls:v1:jobs');
         $commandTester = new CommandTester($command);
@@ -189,7 +189,7 @@ final class CoverallsJobsCommandTest extends ProjectTestCase
         $command->setRootDir($this->rootDir);
 
         $app = new Application();
-        $app->add($command);
+        method_exists($app, 'addCommand') ? $app->addCommand($command) : $app->add($command);
 
         $command = $app->find('coveralls:v1:jobs');
         $commandTester = new CommandTester($command);


### PR DESCRIPTION
This PR increase version constraints on `symfony/*` packages to allow Symfony 8, which will be released this month.
